### PR TITLE
Add new rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ The rules with the following star :star: are included in the config.
 | [jsonc/no-comments](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html) | disallow comments |  | :star: |  |  |
 | [jsonc/no-escape-sequence-in-identifier](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html) | disallow escape sequences in identifiers. | :wrench: |  |  |  |
 | [jsonc/no-hexadecimal-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html) | disallow hexadecimal numeric literals | :wrench: |  |  |  |
+| [jsonc/no-infinity](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html) | disallow Infinity |  |  |  |  |
+| [jsonc/no-nan](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html) | disallow NaN |  |  |  |  |
 | [jsonc/no-number-props](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-octal-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html) | disallow octal numeric literals | :wrench: |  |  |  |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The rules with the following star :star: are included in the config.
 | [jsonc/no-number-props](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-octal-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html) | disallow octal numeric literals | :wrench: |  |  |  |
+| [jsonc/no-plus-sign](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html) | disallow plus sign | :wrench: |  |  |  |
 | [jsonc/no-regexp-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-regexp-literals.html) | disallow RegExp literals |  | :star: | :star: | :star: |
 | [jsonc/no-template-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html) | disallow template literals | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-undefined-value](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html) | disallow `undefined` |  | :star: | :star: | :star: |

--- a/README.md
+++ b/README.md
@@ -169,12 +169,17 @@ The rules with the following star :star: are included in the config.
 | [jsonc/auto](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/auto.html) | apply jsonc rules similar to your configured ESLint core rules | :wrench: |  |  |  |
 | [jsonc/key-name-casing](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html) | enforce naming convention to property key names |  |  |  |  |
 | [jsonc/no-bigint-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html) | disallow BigInt literals |  | :star: | :star: | :star: |
+| [jsonc/no-binary-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html) | disallow binary numeric literals | :wrench: |  |  |  |
 | [jsonc/no-comments](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html) | disallow comments |  | :star: |  |  |
+| [jsonc/no-escape-sequence-in-identifier](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html) | disallow escape sequences in identifiers. | :wrench: |  |  |  |
+| [jsonc/no-hexadecimal-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html) | disallow hexadecimal numeric literals | :wrench: |  |  |  |
 | [jsonc/no-number-props](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
+| [jsonc/no-octal-numeric-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html) | disallow octal numeric literals | :wrench: |  |  |  |
 | [jsonc/no-regexp-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-regexp-literals.html) | disallow RegExp literals |  | :star: | :star: | :star: |
 | [jsonc/no-template-literals](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html) | disallow template literals | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-undefined-value](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html) | disallow `undefined` |  | :star: | :star: | :star: |
+| [jsonc/no-unicode-codepoint-escapes](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html) | disallow Unicode code point escape sequences. | :wrench: |  |  |  |
 | [jsonc/valid-json-number](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html) | disallow invalid number for JSON | :wrench: | :star: | :star: |  |
 | [jsonc/vue-custom-block/no-parsing-error](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/vue-custom-block/no-parsing-error.html) | disallow parsing errors in Vue custom blocks |  | :star: | :star: | :star: |
 
@@ -193,6 +198,7 @@ The rules with the following star :star: are included in the config.
 | [jsonc/no-floating-decimal](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html) | disallow leading or trailing decimal points in numeric literals | :wrench: | :star: | :star: |  |
 | [jsonc/no-multi-str](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-multi-str.html) | disallow multiline strings |  | :star: | :star: |  |
 | [jsonc/no-octal-escape](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html) | disallow octal escape sequences in string literals |  |  |  |  |
+| [jsonc/no-octal](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal.html) | disallow legacy octal literals |  |  |  |  |
 | [jsonc/no-sparse-arrays](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-sparse-arrays.html) | disallow sparse arrays |  | :star: | :star: | :star: |
 | [jsonc/no-useless-escape](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-useless-escape.html) | disallow unnecessary escape usage |  | :star: | :star: | :star: |
 | [jsonc/object-curly-newline](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-newline.html) | enforce consistent line breaks inside braces | :wrench: |  |  |  |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -16,12 +16,17 @@ The rules with the following star :star: are included in the `plugin:jsonc/recom
 | [jsonc/auto](./auto.md) | apply jsonc rules similar to your configured ESLint core rules | :wrench: |  |  |  |
 | [jsonc/key-name-casing](./key-name-casing.md) | enforce naming convention to property key names |  |  |  |  |
 | [jsonc/no-bigint-literals](./no-bigint-literals.md) | disallow BigInt literals |  | :star: | :star: | :star: |
+| [jsonc/no-binary-numeric-literals](./no-binary-numeric-literals.md) | disallow binary numeric literals | :wrench: |  |  |  |
 | [jsonc/no-comments](./no-comments.md) | disallow comments |  | :star: |  |  |
+| [jsonc/no-escape-sequence-in-identifier](./no-escape-sequence-in-identifier.md) | disallow escape sequences in identifiers. | :wrench: |  |  |  |
+| [jsonc/no-hexadecimal-numeric-literals](./no-hexadecimal-numeric-literals.md) | disallow hexadecimal numeric literals | :wrench: |  |  |  |
 | [jsonc/no-number-props](./no-number-props.md) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](./no-numeric-separators.md) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
+| [jsonc/no-octal-numeric-literals](./no-octal-numeric-literals.md) | disallow octal numeric literals | :wrench: |  |  |  |
 | [jsonc/no-regexp-literals](./no-regexp-literals.md) | disallow RegExp literals |  | :star: | :star: | :star: |
 | [jsonc/no-template-literals](./no-template-literals.md) | disallow template literals | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-undefined-value](./no-undefined-value.md) | disallow `undefined` |  | :star: | :star: | :star: |
+| [jsonc/no-unicode-codepoint-escapes](./no-unicode-codepoint-escapes.md) | disallow Unicode code point escape sequences. | :wrench: |  |  |  |
 | [jsonc/valid-json-number](./valid-json-number.md) | disallow invalid number for JSON | :wrench: | :star: | :star: |  |
 | [jsonc/vue-custom-block/no-parsing-error](./vue-custom-block/no-parsing-error.md) | disallow parsing errors in Vue custom blocks |  | :star: | :star: | :star: |
 
@@ -40,6 +45,7 @@ The rules with the following star :star: are included in the `plugin:jsonc/recom
 | [jsonc/no-floating-decimal](./no-floating-decimal.md) | disallow leading or trailing decimal points in numeric literals | :wrench: | :star: | :star: |  |
 | [jsonc/no-multi-str](./no-multi-str.md) | disallow multiline strings |  | :star: | :star: |  |
 | [jsonc/no-octal-escape](./no-octal-escape.md) | disallow octal escape sequences in string literals |  |  |  |  |
+| [jsonc/no-octal](./no-octal.md) | disallow legacy octal literals |  |  |  |  |
 | [jsonc/no-sparse-arrays](./no-sparse-arrays.md) | disallow sparse arrays |  | :star: | :star: | :star: |
 | [jsonc/no-useless-escape](./no-useless-escape.md) | disallow unnecessary escape usage |  | :star: | :star: | :star: |
 | [jsonc/object-curly-newline](./object-curly-newline.md) | enforce consistent line breaks inside braces | :wrench: |  |  |  |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -20,6 +20,8 @@ The rules with the following star :star: are included in the `plugin:jsonc/recom
 | [jsonc/no-comments](./no-comments.md) | disallow comments |  | :star: |  |  |
 | [jsonc/no-escape-sequence-in-identifier](./no-escape-sequence-in-identifier.md) | disallow escape sequences in identifiers. | :wrench: |  |  |  |
 | [jsonc/no-hexadecimal-numeric-literals](./no-hexadecimal-numeric-literals.md) | disallow hexadecimal numeric literals | :wrench: |  |  |  |
+| [jsonc/no-infinity](./no-infinity.md) | disallow Infinity |  |  |  |  |
+| [jsonc/no-nan](./no-nan.md) | disallow NaN |  |  |  |  |
 | [jsonc/no-number-props](./no-number-props.md) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](./no-numeric-separators.md) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-octal-numeric-literals](./no-octal-numeric-literals.md) | disallow octal numeric literals | :wrench: |  |  |  |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -25,6 +25,7 @@ The rules with the following star :star: are included in the `plugin:jsonc/recom
 | [jsonc/no-number-props](./no-number-props.md) | disallow number property keys | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-numeric-separators](./no-numeric-separators.md) | disallow numeric separators | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-octal-numeric-literals](./no-octal-numeric-literals.md) | disallow octal numeric literals | :wrench: |  |  |  |
+| [jsonc/no-plus-sign](./no-plus-sign.md) | disallow plus sign | :wrench: |  |  |  |
 | [jsonc/no-regexp-literals](./no-regexp-literals.md) | disallow RegExp literals |  | :star: | :star: | :star: |
 | [jsonc/no-template-literals](./no-template-literals.md) | disallow template literals | :wrench: | :star: | :star: | :star: |
 | [jsonc/no-undefined-value](./no-undefined-value.md) | disallow `undefined` |  | :star: | :star: | :star: |

--- a/docs/rules/no-binary-numeric-literals.md
+++ b/docs/rules/no-binary-numeric-literals.md
@@ -39,4 +39,4 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-binary-numeric-literals.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-binary-numeric-literals.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-binary-numeric-literals.ts)

--- a/docs/rules/no-binary-numeric-literals.md
+++ b/docs/rules/no-binary-numeric-literals.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-binary-numeric-literals"
+description: "disallow binary numeric literals"
+---
+# jsonc/no-binary-numeric-literals
+
+> disallow binary numeric literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule disallow binary numeric literals
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-binary-numeric-literals: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 10,
+
+    /* ✗ BAD */
+    "BAD": 0b1010
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-binary-numeric-literals.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-binary-numeric-literals.js)

--- a/docs/rules/no-escape-sequence-in-identifier.md
+++ b/docs/rules/no-escape-sequence-in-identifier.md
@@ -39,4 +39,4 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-escape-sequence-in-identifier.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-escape-sequence-in-identifier.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-escape-sequence-in-identifier.ts)

--- a/docs/rules/no-escape-sequence-in-identifier.md
+++ b/docs/rules/no-escape-sequence-in-identifier.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-escape-sequence-in-identifier"
+description: "disallow escape sequences in identifiers."
+---
+# jsonc/no-escape-sequence-in-identifier
+
+> disallow escape sequences in identifiers.
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports disallow escape sequences in identifiers.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-escape-sequence-in-identifier: 'error' */
+{
+    /* ✓ GOOD */
+    GOOD: "GOOD",
+
+    /* ✗ BAD */
+    \u0042\u{41}\u{44}: "BAD"
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-escape-sequence-in-identifier.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-escape-sequence-in-identifier.js)

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -16,6 +16,8 @@ since: "v0.9.0"
 
 This rule is aimed at eliminating floating decimal points and will warn whenever a numeric value has a decimal point but is missing a number either before or after it.
 
+Cannot use floating decimal points when in JSON and JSONC.
+
 <eslint-code-block fix>
 
 <!-- eslint-skip -->
@@ -40,8 +42,10 @@ Nothing.
 ## :couple: Related rules
 
 - [no-floating-decimal]
+- [jsonc/valid-json-number]
 
 [no-floating-decimal]: https://eslint.org/docs/rules/no-floating-decimal
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :rocket: Version
 

--- a/docs/rules/no-hexadecimal-numeric-literals.md
+++ b/docs/rules/no-hexadecimal-numeric-literals.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-hexadecimal-numeric-literals"
+description: "disallow hexadecimal numeric literals"
+---
+# jsonc/no-hexadecimal-numeric-literals
+
+> disallow hexadecimal numeric literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule disallow hexadecimal numeric literals.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-hexadecimal-numeric-literals: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 65535,
+
+    /* ✗ BAD */
+    "BAD": 0xFFFF
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-hexadecimal-numeric-literals.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-hexadecimal-numeric-literals.js)

--- a/docs/rules/no-hexadecimal-numeric-literals.md
+++ b/docs/rules/no-hexadecimal-numeric-literals.md
@@ -39,4 +39,4 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-hexadecimal-numeric-literals.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-hexadecimal-numeric-literals.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-hexadecimal-numeric-literals.ts)

--- a/docs/rules/no-hexadecimal-numeric-literals.md
+++ b/docs/rules/no-hexadecimal-numeric-literals.md
@@ -15,6 +15,8 @@ description: "disallow hexadecimal numeric literals"
 
 This rule disallow hexadecimal numeric literals.
 
+Cannot use hexadecimal numeric literals when in JSON and JSONC.
+
 <eslint-code-block fix>
 
 <!-- eslint-skip -->
@@ -35,6 +37,12 @@ This rule disallow hexadecimal numeric literals.
 ## :wrench: Options
 
 Nothing.
+
+## :couple: Related rules
+
+- [jsonc/valid-json-number]
+
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :mag: Implementation
 

--- a/docs/rules/no-infinity.md
+++ b/docs/rules/no-infinity.md
@@ -14,6 +14,8 @@ description: "disallow Infinity"
 
 This rule reports the use of Infinity.
 
+Cannot use Infinity when in JSON and JSONC.
+
 <eslint-code-block>
 
 <!-- eslint-skip -->
@@ -34,6 +36,12 @@ This rule reports the use of Infinity.
 ## :wrench: Options
 
 Nothing.
+
+## :couple: Related rules
+
+- [jsonc/valid-json-number]
+
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :mag: Implementation
 

--- a/docs/rules/no-infinity.md
+++ b/docs/rules/no-infinity.md
@@ -1,0 +1,41 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-infinity"
+description: "disallow Infinity"
+---
+# jsonc/no-infinity
+
+> disallow Infinity
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+
+## :book: Rule Details
+
+This rule reports the use of Infinity.
+
+<eslint-code-block>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-infinity: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 42,
+
+    /* ✗ BAD */
+    "BAD": Infinity
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-infinity.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-infinity.ts)

--- a/docs/rules/no-nan.md
+++ b/docs/rules/no-nan.md
@@ -14,6 +14,8 @@ description: "disallow NaN"
 
 This rule reports the use of NaN.
 
+Cannot use NaN when in JSON and JSONC.
+
 <eslint-code-block>
 
 <!-- eslint-skip -->
@@ -34,6 +36,12 @@ This rule reports the use of NaN.
 ## :wrench: Options
 
 Nothing.
+
+## :couple: Related rules
+
+- [jsonc/valid-json-number]
+
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :mag: Implementation
 

--- a/docs/rules/no-nan.md
+++ b/docs/rules/no-nan.md
@@ -1,0 +1,41 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-nan"
+description: "disallow NaN"
+---
+# jsonc/no-nan
+
+> disallow NaN
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+
+## :book: Rule Details
+
+This rule reports the use of NaN.
+
+<eslint-code-block>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-nan: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 42,
+
+    /* ✗ BAD */
+    "BAD": NaN
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-nan.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-nan.ts)

--- a/docs/rules/no-numeric-separators.md
+++ b/docs/rules/no-numeric-separators.md
@@ -37,6 +37,12 @@ This rule reports the use of numeric separators.
 
 Nothing.
 
+## :couple: Related rules
+
+- [jsonc/valid-json-number]
+
+[jsonc/valid-json-number]: ./valid-json-number.md
+
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-jsonc v0.6.0

--- a/docs/rules/no-octal-numeric-literals.md
+++ b/docs/rules/no-octal-numeric-literals.md
@@ -36,6 +36,12 @@ This rule disallow octal numeric literals.
 
 Nothing.
 
+## :couple: Related rules
+
+- [jsonc/valid-json-number]
+
+[jsonc/valid-json-number]: ./valid-json-number.md
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-octal-numeric-literals.ts)

--- a/docs/rules/no-octal-numeric-literals.md
+++ b/docs/rules/no-octal-numeric-literals.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-octal-numeric-literals"
+description: "disallow octal numeric literals"
+---
+# jsonc/no-octal-numeric-literals
+
+> disallow octal numeric literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule disallow octal numeric literals.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-octal-numeric-literals: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 511,
+
+    /* ✗ BAD */
+    "BAD": 0o777
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-octal-numeric-literals.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal-numeric-literals.js)

--- a/docs/rules/no-octal-numeric-literals.md
+++ b/docs/rules/no-octal-numeric-literals.md
@@ -39,4 +39,4 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-octal-numeric-literals.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal-numeric-literals.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal-numeric-literals.ts)

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -12,7 +12,7 @@ description: "disallow legacy octal literals"
 
 ## :book: Rule Details
 
-The rule disallows octal literals.
+The rule disallows legacy octal literals.
 
 <eslint-code-block>
 
@@ -38,8 +38,10 @@ Nothing.
 ## :couple: Related rules
 
 - [no-octal]
+- [jsonc/valid-json-number]
 
 [no-octal]: https://eslint.org/docs/rules/no-octal
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :mag: Implementation
 

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -1,0 +1,49 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-octal"
+description: "disallow legacy octal literals"
+---
+# jsonc/no-octal
+
+> disallow legacy octal literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+
+## :book: Rule Details
+
+The rule disallows octal literals.
+
+<eslint-code-block>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-octal: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": 777,
+
+    /* ✗ BAD */
+    "BAD": 0777
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :couple: Related rules
+
+- [no-octal]
+
+[no-octal]: https://eslint.org/docs/rules/no-octal
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-octal.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-octal)</sup>

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -44,6 +44,6 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-octal.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-octal.ts)
 
 <sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-octal)</sup>

--- a/docs/rules/no-plus-sign.md
+++ b/docs/rules/no-plus-sign.md
@@ -1,32 +1,34 @@
 ---
 pageClass: "rule-details"
 sidebarDepth: 0
-title: "jsonc/no-binary-numeric-literals"
-description: "disallow binary numeric literals"
+title: "jsonc/no-plus-sign"
+description: "disallow plus sign"
 ---
-# jsonc/no-binary-numeric-literals
+# jsonc/no-plus-sign
 
-> disallow binary numeric literals
+> disallow plus sign
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 
-This rule disallow binary numeric literals
+This rule disallow plus sign.
+
+Cannot use plus sign when in JSON and JSONC.
 
 <eslint-code-block fix>
 
 <!-- eslint-skip -->
 
 ```json5
-/* eslint jsonc/no-binary-numeric-literals: 'error' */
+/* eslint jsonc/no-plus-sign: 'error' */
 {
     /* ✓ GOOD */
-    "GOOD": 10,
+    "GOOD": 42,
 
     /* ✗ BAD */
-    "BAD": 0b1010
+    "BAD": +42
 }
 ```
 
@@ -44,5 +46,5 @@ Nothing.
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-binary-numeric-literals.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-binary-numeric-literals.ts)
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-plus-sign.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-plus-sign.ts)

--- a/docs/rules/no-unicode-codepoint-escapes.md
+++ b/docs/rules/no-unicode-codepoint-escapes.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "jsonc/no-unicode-codepoint-escapes"
+description: "disallow Unicode code point escape sequences."
+---
+# jsonc/no-unicode-codepoint-escapes
+
+> disallow Unicode code point escape sequences.
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule disallow Unicode code point escape sequences.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/no-unicode-codepoint-escapes: 'error' */
+{
+    /* ✓ GOOD */
+    "GOOD": "\u0041",
+
+    /* ✗ BAD */
+    "BAD": "\u{41}"
+}
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-unicode-codepoint-escapes.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-unicode-codepoint-escapes.js)

--- a/docs/rules/no-unicode-codepoint-escapes.md
+++ b/docs/rules/no-unicode-codepoint-escapes.md
@@ -39,4 +39,4 @@ Nothing.
 ## :mag: Implementation
 
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/no-unicode-codepoint-escapes.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-unicode-codepoint-escapes.js)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/tests/lib/rules/no-unicode-codepoint-escapes.ts)

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -42,8 +42,10 @@ Nothing.
 ## :couple: Related rules
 
 - [space-unary-ops]
+- [jsonc/valid-json-number]
 
 [space-unary-ops]: https://eslint.org/docs/rules/space-unary-ops
+[jsonc/valid-json-number]: ./valid-json-number.md
 
 ## :rocket: Version
 

--- a/docs/rules/valid-json-number.md
+++ b/docs/rules/valid-json-number.md
@@ -37,6 +37,30 @@ This rule reports numbers that cannot be parsed with JSON.
 
 Nothing.
 
+## :couple: Related rules
+
+- [jsonc/no-binary-numeric-literals]
+- [jsonc/no-floating-decimal]
+- [jsonc/no-hexadecimal-numeric-literals]
+- [jsonc/no-infinity]
+- [jsonc/no-nan]
+- [jsonc/no-numeric-separators]
+- [jsonc/no-octal-numeric-literals]
+- [jsonc/no-octal]
+- [jsonc/no-plus-sign]
+- [jsonc/space-unary-ops]
+
+[jsonc/no-binary-numeric-literals]: ./no-binary-numeric-literals.md
+[jsonc/no-floating-decimal]: ./no-floating-decimal.md
+[jsonc/no-hexadecimal-numeric-literals]: ./no-hexadecimal-numeric-literals.md
+[jsonc/no-infinity]: ./no-infinity.md
+[jsonc/no-nan]: ./no-nan.md
+[jsonc/no-numeric-separators]: ./no-numeric-separators.md
+[jsonc/no-octal-numeric-literals]: ./no-octal-numeric-literals.md
+[jsonc/no-octal]: ./no-octal.md
+[jsonc/no-plus-sign]: ./no-plus-sign.md
+[jsonc/space-unary-ops]: ./space-unary-ops.md
+
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-jsonc v0.1.0

--- a/lib/configs/prettier.ts
+++ b/lib/configs/prettier.ts
@@ -1,4 +1,3 @@
-
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -8,18 +7,18 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/array-bracket-newline": "off",
-"jsonc/array-bracket-spacing": "off",
-"jsonc/array-element-newline": "off",
-"jsonc/comma-dangle": "off",
-"jsonc/comma-style": "off",
-"jsonc/indent": "off",
-"jsonc/key-spacing": "off",
-"jsonc/no-floating-decimal": "off",
-"jsonc/object-curly-newline": "off",
-"jsonc/object-curly-spacing": "off",
-"jsonc/object-property-newline": "off",
-"jsonc/quote-props": "off",
-"jsonc/quotes": "off",
-"jsonc/space-unary-ops": "off"
+        "jsonc/array-bracket-spacing": "off",
+        "jsonc/array-element-newline": "off",
+        "jsonc/comma-dangle": "off",
+        "jsonc/comma-style": "off",
+        "jsonc/indent": "off",
+        "jsonc/key-spacing": "off",
+        "jsonc/no-floating-decimal": "off",
+        "jsonc/object-curly-newline": "off",
+        "jsonc/object-curly-spacing": "off",
+        "jsonc/object-property-newline": "off",
+        "jsonc/quote-props": "off",
+        "jsonc/quotes": "off",
+        "jsonc/space-unary-ops": "off",
     },
 }

--- a/lib/configs/prettier.ts
+++ b/lib/configs/prettier.ts
@@ -1,3 +1,4 @@
+
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -7,18 +8,18 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/array-bracket-newline": "off",
-        "jsonc/array-bracket-spacing": "off",
-        "jsonc/array-element-newline": "off",
-        "jsonc/comma-dangle": "off",
-        "jsonc/comma-style": "off",
-        "jsonc/indent": "off",
-        "jsonc/key-spacing": "off",
-        "jsonc/no-floating-decimal": "off",
-        "jsonc/object-curly-newline": "off",
-        "jsonc/object-curly-spacing": "off",
-        "jsonc/object-property-newline": "off",
-        "jsonc/quote-props": "off",
-        "jsonc/quotes": "off",
-        "jsonc/space-unary-ops": "off",
+"jsonc/array-bracket-spacing": "off",
+"jsonc/array-element-newline": "off",
+"jsonc/comma-dangle": "off",
+"jsonc/comma-style": "off",
+"jsonc/indent": "off",
+"jsonc/key-spacing": "off",
+"jsonc/no-floating-decimal": "off",
+"jsonc/object-curly-newline": "off",
+"jsonc/object-curly-spacing": "off",
+"jsonc/object-property-newline": "off",
+"jsonc/quote-props": "off",
+"jsonc/quotes": "off",
+"jsonc/space-unary-ops": "off"
     },
 }

--- a/lib/configs/recommended-with-json.ts
+++ b/lib/configs/recommended-with-json.ts
@@ -1,3 +1,4 @@
+
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -7,22 +8,22 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/comma-dangle": "error",
-        "jsonc/no-bigint-literals": "error",
-        "jsonc/no-comments": "error",
-        "jsonc/no-dupe-keys": "error",
-        "jsonc/no-floating-decimal": "error",
-        "jsonc/no-multi-str": "error",
-        "jsonc/no-number-props": "error",
-        "jsonc/no-numeric-separators": "error",
-        "jsonc/no-regexp-literals": "error",
-        "jsonc/no-sparse-arrays": "error",
-        "jsonc/no-template-literals": "error",
-        "jsonc/no-undefined-value": "error",
-        "jsonc/no-useless-escape": "error",
-        "jsonc/quote-props": "error",
-        "jsonc/quotes": "error",
-        "jsonc/space-unary-ops": "error",
-        "jsonc/valid-json-number": "error",
-        "jsonc/vue-custom-block/no-parsing-error": "error",
+"jsonc/no-bigint-literals": "error",
+"jsonc/no-comments": "error",
+"jsonc/no-dupe-keys": "error",
+"jsonc/no-floating-decimal": "error",
+"jsonc/no-multi-str": "error",
+"jsonc/no-number-props": "error",
+"jsonc/no-numeric-separators": "error",
+"jsonc/no-regexp-literals": "error",
+"jsonc/no-sparse-arrays": "error",
+"jsonc/no-template-literals": "error",
+"jsonc/no-undefined-value": "error",
+"jsonc/no-useless-escape": "error",
+"jsonc/quote-props": "error",
+"jsonc/quotes": "error",
+"jsonc/space-unary-ops": "error",
+"jsonc/valid-json-number": "error",
+"jsonc/vue-custom-block/no-parsing-error": "error"
     },
 }

--- a/lib/configs/recommended-with-json.ts
+++ b/lib/configs/recommended-with-json.ts
@@ -1,4 +1,3 @@
-
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -8,22 +7,22 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/comma-dangle": "error",
-"jsonc/no-bigint-literals": "error",
-"jsonc/no-comments": "error",
-"jsonc/no-dupe-keys": "error",
-"jsonc/no-floating-decimal": "error",
-"jsonc/no-multi-str": "error",
-"jsonc/no-number-props": "error",
-"jsonc/no-numeric-separators": "error",
-"jsonc/no-regexp-literals": "error",
-"jsonc/no-sparse-arrays": "error",
-"jsonc/no-template-literals": "error",
-"jsonc/no-undefined-value": "error",
-"jsonc/no-useless-escape": "error",
-"jsonc/quote-props": "error",
-"jsonc/quotes": "error",
-"jsonc/space-unary-ops": "error",
-"jsonc/valid-json-number": "error",
-"jsonc/vue-custom-block/no-parsing-error": "error"
+        "jsonc/no-bigint-literals": "error",
+        "jsonc/no-comments": "error",
+        "jsonc/no-dupe-keys": "error",
+        "jsonc/no-floating-decimal": "error",
+        "jsonc/no-multi-str": "error",
+        "jsonc/no-number-props": "error",
+        "jsonc/no-numeric-separators": "error",
+        "jsonc/no-regexp-literals": "error",
+        "jsonc/no-sparse-arrays": "error",
+        "jsonc/no-template-literals": "error",
+        "jsonc/no-undefined-value": "error",
+        "jsonc/no-useless-escape": "error",
+        "jsonc/quote-props": "error",
+        "jsonc/quotes": "error",
+        "jsonc/space-unary-ops": "error",
+        "jsonc/valid-json-number": "error",
+        "jsonc/vue-custom-block/no-parsing-error": "error",
     },
 }

--- a/lib/configs/recommended-with-json5.ts
+++ b/lib/configs/recommended-with-json5.ts
@@ -1,4 +1,3 @@
-
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -8,15 +7,15 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/no-bigint-literals": "error",
-"jsonc/no-dupe-keys": "error",
-"jsonc/no-number-props": "error",
-"jsonc/no-numeric-separators": "error",
-"jsonc/no-regexp-literals": "error",
-"jsonc/no-sparse-arrays": "error",
-"jsonc/no-template-literals": "error",
-"jsonc/no-undefined-value": "error",
-"jsonc/no-useless-escape": "error",
-"jsonc/space-unary-ops": "error",
-"jsonc/vue-custom-block/no-parsing-error": "error"
+        "jsonc/no-dupe-keys": "error",
+        "jsonc/no-number-props": "error",
+        "jsonc/no-numeric-separators": "error",
+        "jsonc/no-regexp-literals": "error",
+        "jsonc/no-sparse-arrays": "error",
+        "jsonc/no-template-literals": "error",
+        "jsonc/no-undefined-value": "error",
+        "jsonc/no-useless-escape": "error",
+        "jsonc/space-unary-ops": "error",
+        "jsonc/vue-custom-block/no-parsing-error": "error",
     },
 }

--- a/lib/configs/recommended-with-json5.ts
+++ b/lib/configs/recommended-with-json5.ts
@@ -1,3 +1,4 @@
+
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -7,15 +8,15 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/no-bigint-literals": "error",
-        "jsonc/no-dupe-keys": "error",
-        "jsonc/no-number-props": "error",
-        "jsonc/no-numeric-separators": "error",
-        "jsonc/no-regexp-literals": "error",
-        "jsonc/no-sparse-arrays": "error",
-        "jsonc/no-template-literals": "error",
-        "jsonc/no-undefined-value": "error",
-        "jsonc/no-useless-escape": "error",
-        "jsonc/space-unary-ops": "error",
-        "jsonc/vue-custom-block/no-parsing-error": "error",
+"jsonc/no-dupe-keys": "error",
+"jsonc/no-number-props": "error",
+"jsonc/no-numeric-separators": "error",
+"jsonc/no-regexp-literals": "error",
+"jsonc/no-sparse-arrays": "error",
+"jsonc/no-template-literals": "error",
+"jsonc/no-undefined-value": "error",
+"jsonc/no-useless-escape": "error",
+"jsonc/space-unary-ops": "error",
+"jsonc/vue-custom-block/no-parsing-error": "error"
     },
 }

--- a/lib/configs/recommended-with-jsonc.ts
+++ b/lib/configs/recommended-with-jsonc.ts
@@ -1,3 +1,4 @@
+
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -7,20 +8,20 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/no-bigint-literals": "error",
-        "jsonc/no-dupe-keys": "error",
-        "jsonc/no-floating-decimal": "error",
-        "jsonc/no-multi-str": "error",
-        "jsonc/no-number-props": "error",
-        "jsonc/no-numeric-separators": "error",
-        "jsonc/no-regexp-literals": "error",
-        "jsonc/no-sparse-arrays": "error",
-        "jsonc/no-template-literals": "error",
-        "jsonc/no-undefined-value": "error",
-        "jsonc/no-useless-escape": "error",
-        "jsonc/quote-props": "error",
-        "jsonc/quotes": "error",
-        "jsonc/space-unary-ops": "error",
-        "jsonc/valid-json-number": "error",
-        "jsonc/vue-custom-block/no-parsing-error": "error",
+"jsonc/no-dupe-keys": "error",
+"jsonc/no-floating-decimal": "error",
+"jsonc/no-multi-str": "error",
+"jsonc/no-number-props": "error",
+"jsonc/no-numeric-separators": "error",
+"jsonc/no-regexp-literals": "error",
+"jsonc/no-sparse-arrays": "error",
+"jsonc/no-template-literals": "error",
+"jsonc/no-undefined-value": "error",
+"jsonc/no-useless-escape": "error",
+"jsonc/quote-props": "error",
+"jsonc/quotes": "error",
+"jsonc/space-unary-ops": "error",
+"jsonc/valid-json-number": "error",
+"jsonc/vue-custom-block/no-parsing-error": "error"
     },
 }

--- a/lib/configs/recommended-with-jsonc.ts
+++ b/lib/configs/recommended-with-jsonc.ts
@@ -1,4 +1,3 @@
-
 import path from "path"
 const base = require.resolve("./base")
 const baseExtend =
@@ -8,20 +7,20 @@ export = {
     rules: {
         // eslint-plugin-jsonc rules
         "jsonc/no-bigint-literals": "error",
-"jsonc/no-dupe-keys": "error",
-"jsonc/no-floating-decimal": "error",
-"jsonc/no-multi-str": "error",
-"jsonc/no-number-props": "error",
-"jsonc/no-numeric-separators": "error",
-"jsonc/no-regexp-literals": "error",
-"jsonc/no-sparse-arrays": "error",
-"jsonc/no-template-literals": "error",
-"jsonc/no-undefined-value": "error",
-"jsonc/no-useless-escape": "error",
-"jsonc/quote-props": "error",
-"jsonc/quotes": "error",
-"jsonc/space-unary-ops": "error",
-"jsonc/valid-json-number": "error",
-"jsonc/vue-custom-block/no-parsing-error": "error"
+        "jsonc/no-dupe-keys": "error",
+        "jsonc/no-floating-decimal": "error",
+        "jsonc/no-multi-str": "error",
+        "jsonc/no-number-props": "error",
+        "jsonc/no-numeric-separators": "error",
+        "jsonc/no-regexp-literals": "error",
+        "jsonc/no-sparse-arrays": "error",
+        "jsonc/no-template-literals": "error",
+        "jsonc/no-undefined-value": "error",
+        "jsonc/no-useless-escape": "error",
+        "jsonc/quote-props": "error",
+        "jsonc/quotes": "error",
+        "jsonc/space-unary-ops": "error",
+        "jsonc/valid-json-number": "error",
+        "jsonc/vue-custom-block/no-parsing-error": "error",
     },
 }

--- a/lib/rules/auto.ts
+++ b/lib/rules/auto.ts
@@ -17,6 +17,9 @@ export default createRule("auto", {
         type: "suggestion",
     },
     create(context, params) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         const autoConfig = getAutoConfig(context.getFilename())
 
         const visitor: RuleListener = {}

--- a/lib/rules/no-bigint-literals.ts
+++ b/lib/rules/no-bigint-literals.ts
@@ -16,6 +16,9 @@ export default createRule("no-bigint-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONLiteral(node: AST.JSONLiteral) {
                 if (node.bigint != null) {

--- a/lib/rules/no-binary-numeric-literals.ts
+++ b/lib/rules/no-binary-numeric-literals.ts
@@ -20,6 +20,9 @@ export default createRule("no-binary-numeric-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONLiteral(node: AST.JSONLiteral) {
                 if (

--- a/lib/rules/no-binary-numeric-literals.ts
+++ b/lib/rules/no-binary-numeric-literals.ts
@@ -1,0 +1,43 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+const binaryNumericLiteralPattern = /^0[bB]/u
+
+export default createRule("no-binary-numeric-literals", {
+    meta: {
+        docs: {
+            description: "disallow binary numeric literals",
+            // TODO major version recommended: ["json","jsonc","json5"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Binary numeric literals should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            JSONLiteral(node: AST.JSONLiteral) {
+                if (
+                    typeof node.value === "number" &&
+                    binaryNumericLiteralPattern.test(node.raw)
+                ) {
+                    context.report({
+                        loc: node.loc,
+                        messageId: "disallow",
+                        fix: (fixer) => {
+                            return fixer.replaceTextRange(
+                                node.range,
+                                `${node.value}`,
+                            )
+                        },
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-escape-sequence-in-identifier.ts
+++ b/lib/rules/no-escape-sequence-in-identifier.ts
@@ -19,6 +19,9 @@ export default createRule("no-escape-sequence-in-identifier", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         const sourceCode = context.getSourceCode()
         return {
             JSONIdentifier(node: AST.JSONIdentifier) {

--- a/lib/rules/no-escape-sequence-in-identifier.ts
+++ b/lib/rules/no-escape-sequence-in-identifier.ts
@@ -1,0 +1,65 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+import { PatternMatcher } from "eslint-utils"
+
+export default createRule("no-escape-sequence-in-identifier", {
+    meta: {
+        docs: {
+            description: "disallow escape sequences in identifiers.",
+            // TODO major version recommended: ["json","jsonc","json5"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Escape sequence in identifiers should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        const sourceCode = context.getSourceCode()
+        return {
+            JSONIdentifier(node: AST.JSONIdentifier) {
+                verify(node)
+            },
+        }
+
+        /**
+         * verify
+         */
+        function verify(node: AST.JSONNode) {
+            const escapeMatcher = new PatternMatcher(
+                /\\u\{[\da-fA-F]+\}|\\u\d{4}/gu,
+            )
+            const text = sourceCode.text.slice(...node.range)
+            for (const match of escapeMatcher.execAll(text)) {
+                const start = match.index
+                const end = start + match[0].length
+                const range: [number, number] = [
+                    start + node.range[0],
+                    end + node.range[0],
+                ]
+                context.report({
+                    loc: {
+                        start: sourceCode.getLocFromIndex(range[0]),
+                        end: sourceCode.getLocFromIndex(range[1]),
+                    },
+                    messageId: "disallow",
+                    fix(fixer) {
+                        const codePointStr =
+                            match[0][2] === "{"
+                                ? text.slice(start + 3, end - 1)
+                                : text.slice(start + 2, end)
+                        const codePoint = Number(`0x${codePointStr}`)
+                        return fixer.replaceTextRange(
+                            range,
+                            String.fromCodePoint(codePoint),
+                        )
+                    },
+                })
+            }
+        }
+    },
+})

--- a/lib/rules/no-hexadecimal-numeric-literals.ts
+++ b/lib/rules/no-hexadecimal-numeric-literals.ts
@@ -1,0 +1,43 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+const hexadecimalNumericLiteralPattern = /^0[xX]/u
+
+export default createRule("no-hexadecimal-numeric-literals", {
+    meta: {
+        docs: {
+            description: "disallow hexadecimal numeric literals",
+            // TODO major version recommended: ["json","jsonc"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Hexadecimal numeric literals should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            JSONLiteral(node: AST.JSONLiteral) {
+                if (
+                    typeof node.value === "number" &&
+                    hexadecimalNumericLiteralPattern.test(node.raw)
+                ) {
+                    context.report({
+                        loc: node.loc,
+                        messageId: "disallow",
+                        fix: (fixer) => {
+                            return fixer.replaceTextRange(
+                                node.range,
+                                `${node.value}`,
+                            )
+                        },
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-hexadecimal-numeric-literals.ts
+++ b/lib/rules/no-hexadecimal-numeric-literals.ts
@@ -20,6 +20,9 @@ export default createRule("no-hexadecimal-numeric-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONLiteral(node: AST.JSONLiteral) {
                 if (

--- a/lib/rules/no-infinity.ts
+++ b/lib/rules/no-infinity.ts
@@ -1,0 +1,35 @@
+import type { AST } from "jsonc-eslint-parser"
+import { isNumberIdentifier } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+export default createRule("no-infinity", {
+    meta: {
+        docs: {
+            description: "disallow Infinity",
+            // TODO major version recommended: ["json","jsonc"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        messages: {
+            disallow: "Infinity should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            JSONIdentifier(node: AST.JSONIdentifier) {
+                if (!isNumberIdentifier(node)) {
+                    return
+                }
+                if (node.name === "Infinity") {
+                    context.report({
+                        loc: node.loc,
+                        messageId: "disallow",
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-infinity.ts
+++ b/lib/rules/no-infinity.ts
@@ -18,6 +18,9 @@ export default createRule("no-infinity", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONIdentifier(node: AST.JSONIdentifier) {
                 if (!isNumberIdentifier(node)) {

--- a/lib/rules/no-nan.ts
+++ b/lib/rules/no-nan.ts
@@ -1,0 +1,35 @@
+import type { AST } from "jsonc-eslint-parser"
+import { isNumberIdentifier } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+export default createRule("no-nan", {
+    meta: {
+        docs: {
+            description: "disallow NaN",
+            // TODO major version recommended: ["json","jsonc"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        messages: {
+            disallow: "NaN should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            JSONIdentifier(node: AST.JSONIdentifier) {
+                if (!isNumberIdentifier(node)) {
+                    return
+                }
+                if (node.name === "NaN") {
+                    context.report({
+                        loc: node.loc,
+                        messageId: "disallow",
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-nan.ts
+++ b/lib/rules/no-nan.ts
@@ -18,6 +18,9 @@ export default createRule("no-nan", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONIdentifier(node: AST.JSONIdentifier) {
                 if (!isNumberIdentifier(node)) {

--- a/lib/rules/no-number-props.ts
+++ b/lib/rules/no-number-props.ts
@@ -17,6 +17,9 @@ export default createRule("no-number-props", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONProperty(node: AST.JSONProperty) {
                 if (node.key.type !== "JSONLiteral") {

--- a/lib/rules/no-octal-numeric-literals.ts
+++ b/lib/rules/no-octal-numeric-literals.ts
@@ -1,0 +1,43 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+const octalNumericLiteralPattern = /^0[oO]/u
+
+export default createRule("no-octal-numeric-literals", {
+    meta: {
+        docs: {
+            description: "disallow octal numeric literals",
+            // TODO major version recommended: ["json","jsonc","json5"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Octal numeric literals should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return {
+            JSONLiteral(node: AST.JSONLiteral) {
+                if (
+                    typeof node.value === "number" &&
+                    octalNumericLiteralPattern.test(node.raw)
+                ) {
+                    context.report({
+                        loc: node.loc,
+                        messageId: "disallow",
+                        fix: (fixer) => {
+                            return fixer.replaceTextRange(
+                                node.range,
+                                `${node.value}`,
+                            )
+                        },
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-octal-numeric-literals.ts
+++ b/lib/rules/no-octal-numeric-literals.ts
@@ -20,6 +20,9 @@ export default createRule("no-octal-numeric-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONLiteral(node: AST.JSONLiteral) {
                 if (

--- a/lib/rules/no-octal.ts
+++ b/lib/rules/no-octal.ts
@@ -1,0 +1,21 @@
+import { createRule, defineWrapperListener, getCoreRule } from "../utils"
+const coreRule = getCoreRule("no-octal")
+
+export default createRule("no-octal", {
+    meta: {
+        docs: {
+            description: "disallow legacy octal literals",
+            // TODO major version recommended: ["json","jsonc","json5"],
+            recommended: null,
+            extensionRule: true,
+            layout: false,
+        },
+        fixable: coreRule.meta!.fixable,
+        schema: coreRule.meta!.schema!,
+        messages: coreRule.meta!.messages!,
+        type: coreRule.meta!.type!,
+    },
+    create(context) {
+        return defineWrapperListener(coreRule, context, context.options)
+    },
+})

--- a/lib/rules/no-plus-sign.ts
+++ b/lib/rules/no-plus-sign.ts
@@ -1,0 +1,45 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+
+export default createRule("no-plus-sign", {
+    meta: {
+        docs: {
+            description: "disallow plus sign",
+            // TODO major version recommended: ["json","jsonc"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Plus sign should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
+        const sourceCode = context.getSourceCode()
+        return {
+            JSONUnaryExpression(node: AST.JSONUnaryExpression) {
+                if (node.operator === "+") {
+                    const operator = sourceCode.getFirstToken(
+                        node as any,
+                        (token) =>
+                            token.type === "Punctuator" &&
+                            token.value === node.operator,
+                    )
+                    context.report({
+                        loc: operator?.loc || node.loc,
+                        messageId: "disallow",
+                        fix(fixer) {
+                            return operator ? fixer.remove(operator) : null
+                        },
+                    })
+                }
+            },
+        }
+    },
+})

--- a/lib/rules/no-regexp-literals.ts
+++ b/lib/rules/no-regexp-literals.ts
@@ -16,6 +16,9 @@ export default createRule("no-regexp-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONLiteral(node: AST.JSONLiteral) {
                 if (node.regex) {

--- a/lib/rules/no-template-literals.ts
+++ b/lib/rules/no-template-literals.ts
@@ -17,6 +17,9 @@ export default createRule("no-template-literals", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONTemplateLiteral(node: AST.JSONTemplateLiteral) {
                 context.report({

--- a/lib/rules/no-undefined-value.ts
+++ b/lib/rules/no-undefined-value.ts
@@ -17,6 +17,9 @@ export default createRule("no-undefined-value", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         return {
             JSONIdentifier(node: AST.JSONIdentifier) {
                 if (!isUndefinedIdentifier(node)) {

--- a/lib/rules/no-unicode-codepoint-escapes.ts
+++ b/lib/rules/no-unicode-codepoint-escapes.ts
@@ -1,0 +1,89 @@
+import type { AST } from "jsonc-eslint-parser"
+import { createRule } from "../utils"
+import { PatternMatcher } from "eslint-utils"
+
+export default createRule("no-unicode-codepoint-escapes", {
+    meta: {
+        docs: {
+            description: "disallow Unicode code point escape sequences.",
+            // TODO major version recommended: ["json","jsonc","json5"],
+            recommended: null,
+            extensionRule: false,
+            layout: false,
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Unicode code point escape sequence should not be used.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        const sourceCode = context.getSourceCode()
+        return {
+            JSONIdentifier(node: AST.JSONIdentifier) {
+                verify(node)
+            },
+            JSONLiteral(node: AST.JSONLiteral) {
+                if (typeof node.value === "string") {
+                    verify(node)
+                }
+            },
+            JSONTemplateElement(node: AST.JSONTemplateElement) {
+                verify(node)
+            },
+        }
+
+        /**
+         * verify
+         */
+        function verify(node: AST.JSONNode) {
+            const codePointEscapeMatcher = new PatternMatcher(
+                /\\u\{[\da-fA-F]+\}/gu,
+            )
+            const text = sourceCode.text.slice(...node.range)
+            for (const match of codePointEscapeMatcher.execAll(text)) {
+                const start = match.index
+                const end = start + match[0].length
+                const range = [start + node.range[0], end + node.range[0]]
+                context.report({
+                    loc: {
+                        start: sourceCode.getLocFromIndex(range[0]),
+                        end: sourceCode.getLocFromIndex(range[1]),
+                    },
+                    messageId: "disallow",
+                    fix(fixer) {
+                        const codePointStr = text.slice(start + 3, end - 1)
+                        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
+                        let codePoint = Number(`0x${codePointStr}`)
+                        let replacement = null
+                        if (codePoint <= 0xffff) {
+                            // BMP code point
+                            replacement = toHex(codePoint)
+                        } else {
+                            // Astral code point; split in surrogate halves
+                            // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+                            codePoint -= 0x10000
+                            const highSurrogate = (codePoint >> 10) + 0xd800
+                            const lowSurrogate = (codePoint % 0x400) + 0xdc00
+                            replacement = `${toHex(highSurrogate)}\\u${toHex(
+                                lowSurrogate,
+                            )}`
+                        }
+                        return fixer.replaceTextRange(
+                            [range[0] + 2, range[1]],
+                            replacement,
+                        )
+                    },
+                })
+            }
+        }
+
+        /**
+         * Number to Hex
+         */
+        function toHex(num: number) {
+            return `0000${num.toString(16).toUpperCase()}`.substr(-4)
+        }
+    },
+})

--- a/lib/rules/no-unicode-codepoint-escapes.ts
+++ b/lib/rules/no-unicode-codepoint-escapes.ts
@@ -19,6 +19,9 @@ export default createRule("no-unicode-codepoint-escapes", {
         type: "problem",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         const sourceCode = context.getSourceCode()
         return {
             JSONIdentifier(node: AST.JSONIdentifier) {

--- a/lib/rules/sort-keys.ts
+++ b/lib/rules/sort-keys.ts
@@ -88,6 +88,9 @@ export default createRule("sort-keys", {
         type: "suggestion",
     },
     create(context) {
+        if (!context.parserServices.isJSON) {
+            return {}
+        }
         // Parse options.
         const order: Option = context.options[0] || "asc"
         const options = context.options[1]

--- a/lib/rules/valid-json-number.ts
+++ b/lib/rules/valid-json-number.ts
@@ -4,6 +4,8 @@ import { isNumberIdentifier } from "jsonc-eslint-parser"
 import type { RuleListener } from "../types"
 import { createRule } from "../utils"
 
+const nonDecimalNumericLiteralPattern = /^0[oOxXbB\d]/u
+
 /**
  * Checks if the given string is valid number as JSON.
  */
@@ -113,18 +115,15 @@ export default createRule("valid-json-number", {
                     })
                     return
                 }
-                if (
-                    text.startsWith("0x") ||
-                    text.startsWith("0o") ||
-                    text.startsWith("0b")
-                ) {
+                if (nonDecimalNumericLiteralPattern.test(text)) {
                     context.report({
                         loc: node.loc,
-                        messageId: text.startsWith("0x")
-                            ? "invalidHex"
-                            : text.startsWith("0o")
-                            ? "invalidOctal"
-                            : "invalidBinary",
+                        messageId:
+                            text[1].toLowerCase() === "x"
+                                ? "invalidHex"
+                                : text[1].toLowerCase() === "b"
+                                ? "invalidBinary"
+                                : "invalidOctal",
                         fix: buildFix(node),
                     })
                     return

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -1,4 +1,3 @@
-
 import type { RuleModule } from "../types"
 import arrayBracketNewline from "../rules/array-bracket-newline"
 import arrayBracketSpacing from "../rules/array-bracket-spacing"
@@ -24,6 +23,7 @@ import noNumericSeparators from "../rules/no-numeric-separators"
 import noOctalEscape from "../rules/no-octal-escape"
 import noOctalNumericLiterals from "../rules/no-octal-numeric-literals"
 import noOctal from "../rules/no-octal"
+import noPlusSign from "../rules/no-plus-sign"
 import noRegexpLiterals from "../rules/no-regexp-literals"
 import noSparseArrays from "../rules/no-sparse-arrays"
 import noTemplateLiterals from "../rules/no-template-literals"
@@ -41,5 +41,44 @@ import validJsonNumber from "../rules/valid-json-number"
 import vueCustomBlockNoParsingError from "../rules/vue-custom-block/no-parsing-error"
 
 export const rules = [
-    arrayBracketNewline,arrayBracketSpacing,arrayElementNewline,auto,commaDangle,commaStyle,indent,keyNameCasing,keySpacing,noBigintLiterals,noBinaryNumericLiterals,noComments,noDupeKeys,noEscapeSequenceInIdentifier,noFloatingDecimal,noHexadecimalNumericLiterals,noInfinity,noMultiStr,noNan,noNumberProps,noNumericSeparators,noOctalEscape,noOctalNumericLiterals,noOctal,noRegexpLiterals,noSparseArrays,noTemplateLiterals,noUndefinedValue,noUnicodeCodepointEscapes,noUselessEscape,objectCurlyNewline,objectCurlySpacing,objectPropertyNewline,quoteProps,quotes,sortKeys,spaceUnaryOps,validJsonNumber,vueCustomBlockNoParsingError
+    arrayBracketNewline,
+    arrayBracketSpacing,
+    arrayElementNewline,
+    auto,
+    commaDangle,
+    commaStyle,
+    indent,
+    keyNameCasing,
+    keySpacing,
+    noBigintLiterals,
+    noBinaryNumericLiterals,
+    noComments,
+    noDupeKeys,
+    noEscapeSequenceInIdentifier,
+    noFloatingDecimal,
+    noHexadecimalNumericLiterals,
+    noInfinity,
+    noMultiStr,
+    noNan,
+    noNumberProps,
+    noNumericSeparators,
+    noOctalEscape,
+    noOctalNumericLiterals,
+    noOctal,
+    noPlusSign,
+    noRegexpLiterals,
+    noSparseArrays,
+    noTemplateLiterals,
+    noUndefinedValue,
+    noUnicodeCodepointEscapes,
+    noUselessEscape,
+    objectCurlyNewline,
+    objectCurlySpacing,
+    objectPropertyNewline,
+    quoteProps,
+    quotes,
+    sortKeys,
+    spaceUnaryOps,
+    validJsonNumber,
+    vueCustomBlockNoParsingError,
 ] as RuleModule[]

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -1,3 +1,4 @@
+
 import type { RuleModule } from "../types"
 import arrayBracketNewline from "../rules/array-bracket-newline"
 import arrayBracketSpacing from "../rules/array-bracket-spacing"
@@ -15,7 +16,9 @@ import noDupeKeys from "../rules/no-dupe-keys"
 import noEscapeSequenceInIdentifier from "../rules/no-escape-sequence-in-identifier"
 import noFloatingDecimal from "../rules/no-floating-decimal"
 import noHexadecimalNumericLiterals from "../rules/no-hexadecimal-numeric-literals"
+import noInfinity from "../rules/no-infinity"
 import noMultiStr from "../rules/no-multi-str"
+import noNan from "../rules/no-nan"
 import noNumberProps from "../rules/no-number-props"
 import noNumericSeparators from "../rules/no-numeric-separators"
 import noOctalEscape from "../rules/no-octal-escape"
@@ -38,41 +41,5 @@ import validJsonNumber from "../rules/valid-json-number"
 import vueCustomBlockNoParsingError from "../rules/vue-custom-block/no-parsing-error"
 
 export const rules = [
-    arrayBracketNewline,
-    arrayBracketSpacing,
-    arrayElementNewline,
-    auto,
-    commaDangle,
-    commaStyle,
-    indent,
-    keyNameCasing,
-    keySpacing,
-    noBigintLiterals,
-    noBinaryNumericLiterals,
-    noComments,
-    noDupeKeys,
-    noEscapeSequenceInIdentifier,
-    noFloatingDecimal,
-    noHexadecimalNumericLiterals,
-    noMultiStr,
-    noNumberProps,
-    noNumericSeparators,
-    noOctalEscape,
-    noOctalNumericLiterals,
-    noOctal,
-    noRegexpLiterals,
-    noSparseArrays,
-    noTemplateLiterals,
-    noUndefinedValue,
-    noUnicodeCodepointEscapes,
-    noUselessEscape,
-    objectCurlyNewline,
-    objectCurlySpacing,
-    objectPropertyNewline,
-    quoteProps,
-    quotes,
-    sortKeys,
-    spaceUnaryOps,
-    validJsonNumber,
-    vueCustomBlockNoParsingError,
+    arrayBracketNewline,arrayBracketSpacing,arrayElementNewline,auto,commaDangle,commaStyle,indent,keyNameCasing,keySpacing,noBigintLiterals,noBinaryNumericLiterals,noComments,noDupeKeys,noEscapeSequenceInIdentifier,noFloatingDecimal,noHexadecimalNumericLiterals,noInfinity,noMultiStr,noNan,noNumberProps,noNumericSeparators,noOctalEscape,noOctalNumericLiterals,noOctal,noRegexpLiterals,noSparseArrays,noTemplateLiterals,noUndefinedValue,noUnicodeCodepointEscapes,noUselessEscape,objectCurlyNewline,objectCurlySpacing,objectPropertyNewline,quoteProps,quotes,sortKeys,spaceUnaryOps,validJsonNumber,vueCustomBlockNoParsingError
 ] as RuleModule[]

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -9,17 +9,23 @@ import indent from "../rules/indent"
 import keyNameCasing from "../rules/key-name-casing"
 import keySpacing from "../rules/key-spacing"
 import noBigintLiterals from "../rules/no-bigint-literals"
+import noBinaryNumericLiterals from "../rules/no-binary-numeric-literals"
 import noComments from "../rules/no-comments"
 import noDupeKeys from "../rules/no-dupe-keys"
+import noEscapeSequenceInIdentifier from "../rules/no-escape-sequence-in-identifier"
 import noFloatingDecimal from "../rules/no-floating-decimal"
+import noHexadecimalNumericLiterals from "../rules/no-hexadecimal-numeric-literals"
 import noMultiStr from "../rules/no-multi-str"
 import noNumberProps from "../rules/no-number-props"
 import noNumericSeparators from "../rules/no-numeric-separators"
 import noOctalEscape from "../rules/no-octal-escape"
+import noOctalNumericLiterals from "../rules/no-octal-numeric-literals"
+import noOctal from "../rules/no-octal"
 import noRegexpLiterals from "../rules/no-regexp-literals"
 import noSparseArrays from "../rules/no-sparse-arrays"
 import noTemplateLiterals from "../rules/no-template-literals"
 import noUndefinedValue from "../rules/no-undefined-value"
+import noUnicodeCodepointEscapes from "../rules/no-unicode-codepoint-escapes"
 import noUselessEscape from "../rules/no-useless-escape"
 import objectCurlyNewline from "../rules/object-curly-newline"
 import objectCurlySpacing from "../rules/object-curly-spacing"
@@ -42,17 +48,23 @@ export const rules = [
     keyNameCasing,
     keySpacing,
     noBigintLiterals,
+    noBinaryNumericLiterals,
     noComments,
     noDupeKeys,
+    noEscapeSequenceInIdentifier,
     noFloatingDecimal,
+    noHexadecimalNumericLiterals,
     noMultiStr,
     noNumberProps,
     noNumericSeparators,
     noOctalEscape,
+    noOctalNumericLiterals,
+    noOctal,
     noRegexpLiterals,
     noSparseArrays,
     noTemplateLiterals,
     noUndefinedValue,
+    noUnicodeCodepointEscapes,
     noUselessEscape,
     objectCurlyNewline,
     objectCurlySpacing,

--- a/tests/lib/rules/no-binary-numeric-literals.ts
+++ b/tests/lib/rules/no-binary-numeric-literals.ts
@@ -1,0 +1,25 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-binary-numeric-literals"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-binary-numeric-literals", rule as any, {
+    valid: ["0", "1010"],
+    invalid: [
+        {
+            code: `0b1010`,
+            output: `10`,
+            errors: ["Binary numeric literals should not be used."],
+        },
+        {
+            code: `0B1010`,
+            output: `10`,
+            errors: ["Binary numeric literals should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-escape-sequence-in-identifier.ts
+++ b/tests/lib/rules/no-escape-sequence-in-identifier.ts
@@ -1,0 +1,33 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-escape-sequence-in-identifier"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-escape-sequence-in-identifier", rule as any, {
+    valid: ["{key: 42}"],
+    invalid: [
+        {
+            code: `{\\u0041_\\u{42}: "\\u0043\\u{44}"}`,
+            output: `{A_B: "\\u0043\\u{44}"}`,
+            errors: [
+                {
+                    message:
+                        "Escape sequence in identifiers should not be used.",
+                    line: 1,
+                    column: 2,
+                },
+                {
+                    message:
+                        "Escape sequence in identifiers should not be used.",
+                    line: 1,
+                    column: 9,
+                },
+            ],
+        },
+    ],
+})

--- a/tests/lib/rules/no-hexadecimal-numeric-literals.ts
+++ b/tests/lib/rules/no-hexadecimal-numeric-literals.ts
@@ -1,0 +1,30 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-hexadecimal-numeric-literals"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-hexadecimal-numeric-literals", rule as any, {
+    valid: ["0", "777", '"FFF"'],
+    invalid: [
+        {
+            code: `0x777`,
+            output: `1911`,
+            errors: ["Hexadecimal numeric literals should not be used."],
+        },
+        {
+            code: `0X777`,
+            output: `1911`,
+            errors: ["Hexadecimal numeric literals should not be used."],
+        },
+        {
+            code: `0xFFFF`,
+            output: `65535`,
+            errors: ["Hexadecimal numeric literals should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-infinity.ts
+++ b/tests/lib/rules/no-infinity.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-infinity"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-infinity", rule as any, {
+    valid: ["NaN", "42", '"foo"', "{Infinity:42}"],
+    invalid: [
+        {
+            code: `Infinity`,
+            errors: ["Infinity should not be used."],
+        },
+        {
+            code: `+Infinity`,
+            errors: ["Infinity should not be used."],
+        },
+        {
+            code: `-Infinity`,
+            errors: ["Infinity should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-nan.ts
+++ b/tests/lib/rules/no-nan.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-nan"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-nan", rule as any, {
+    valid: ["Infinity", "1234", '"foo"', "{NaN:42}"],
+    invalid: [
+        {
+            code: `NaN`,
+            errors: ["NaN should not be used."],
+        },
+        {
+            code: `+NaN`,
+            errors: ["NaN should not be used."],
+        },
+        {
+            code: `-NaN`,
+            errors: ["NaN should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-octal-numeric-literals.ts
+++ b/tests/lib/rules/no-octal-numeric-literals.ts
@@ -1,0 +1,25 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-octal-numeric-literals"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-octal-numeric-literals", rule as any, {
+    valid: ["0", "777"],
+    invalid: [
+        {
+            code: `0o777`,
+            output: `511`,
+            errors: ["Octal numeric literals should not be used."],
+        },
+        {
+            code: `0O777`,
+            output: `511`,
+            errors: ["Octal numeric literals should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-octal.ts
+++ b/tests/lib/rules/no-octal.ts
@@ -1,0 +1,23 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-octal"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-octal", rule as any, {
+    valid: ["0", "1", "9"],
+    invalid: [
+        {
+            code: `01`,
+            errors: ["Octal literals should not be used."],
+        },
+        {
+            code: `09`,
+            errors: ["Octal literals should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-plus-sign.ts
+++ b/tests/lib/rules/no-plus-sign.ts
@@ -1,0 +1,25 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-plus-sign"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-plus-sign", rule as any, {
+    valid: ["42", "-42", "-42.0"],
+    invalid: [
+        {
+            code: `+42`,
+            output: `42`,
+            errors: ["Plus sign should not be used."],
+        },
+        {
+            code: `+ 42`,
+            output: ` 42`,
+            errors: ["Plus sign should not be used."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-unicode-codepoint-escapes.ts
+++ b/tests/lib/rules/no-unicode-codepoint-escapes.ts
@@ -1,0 +1,40 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-unicode-codepoint-escapes"
+
+const tester = new RuleTester({
+    parser: require.resolve("jsonc-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2020,
+    },
+})
+
+tester.run("no-unicode-codepoint-escapes", rule as any, {
+    valid: ['"\\u0041"', '{"\\u0041": "string"}', "`\\u0042`"],
+    invalid: [
+        {
+            code: `"\\u{41}"`,
+            output: `"\\u0041"`,
+            errors: ["Unicode code point escape sequence should not be used."],
+        },
+        {
+            code: `{"\\u{41}": "string"}`,
+            output: `{"\\u0041": "string"}`,
+            errors: ["Unicode code point escape sequence should not be used."],
+        },
+        {
+            code: `{a\\u{41}: "string"}`,
+            output: `{a\\u0041: "string"}`,
+            errors: ["Unicode code point escape sequence should not be used."],
+        },
+        {
+            code: "`\\u{42}`",
+            output: "`\\u0042`",
+            errors: ["Unicode code point escape sequence should not be used."],
+        },
+        {
+            code: '"\\u{20BB7}"',
+            output: '"\\uD842\\uDFB7"',
+            errors: ["Unicode code point escape sequence should not be used."],
+        },
+    ],
+})

--- a/tools/new-rule.ts
+++ b/tools/new-rule.ts
@@ -39,6 +39,9 @@ export default createRule("${ruleId}", {
         type: coreRule.meta!.type!,
     },
     create(context) {
+        // if (!context.parserServices.isJSON) {
+        //     return {}
+        // }
         return defineWrapperListener(coreRule, context, context.options)
     },
 })

--- a/typings/eslint-utils/index.d.ts
+++ b/typings/eslint-utils/index.d.ts
@@ -37,11 +37,22 @@ declare module "eslint-utils" {
     export const isOpeningParenToken: unknown
     export const isParenthesized: unknown
     export const isSemicolonToken: unknown
-    export const PatternMatcher: unknown
     export const ReferenceTracker: {
         READ: never
         CALL: never
         CONSTRUCT: never
         new (): never
+    }
+    export class PatternMatcher {
+        public constructor(pattern: RegExp, options?: { escaped?: boolean })
+
+        public execAll(str: string): IterableIterator<RegExpExecArray>
+
+        public test(str: string): boolean
+
+        public [Symbol.replace](
+            str: string,
+            replacer: string | ((...ss: string[]) => string),
+        ): string
     }
 }


### PR DESCRIPTION
- Add `jsonc/no-octal` rule that disallow legacy octal literals.
- Add `jsonc/no-binary-numeric-literals` rule that disallow binary numeric literals.
- Add `jsonc/no-octal-numeric-literals` rule that disallow octal numeric literals.
- Add `jsonc/no-hexadecimal-numeric-literals` rule that disallow hexadecimal numeric literals.
- Add `jsonc/no-unicode-codepoint-escapes` rule that disallow Unicode code point escape sequences.
- Add `jsonc/no-escape-sequence-in-identifier` rule that disallow escape sequences in identifiers.
- Add `jsonc/no-nan` rule that disallow NaN.
- Add `jsonc/no-infinity` rule that disallow Infinity.
- Add `jsonc/no-plus-sign` rule that disallow plus sign.