### PR TITLE
Change configs provided by plugin to parse the `.jsonc` extension by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ module.exports = {
   // Add an `overrides` section to add a parser configuration for json.
   overrides: [
     {
-      files: ["*.json", "*.json5"],
+      files: ["*.json", "*.json5", "*.jsonc"],
       parser: "jsonc-eslint-parser",
     },
   ],

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -61,7 +61,7 @@ module.exports = {
   // Add an `overrides` section to add a parser configuration for json.
   overrides: [
     {
-      files: ["*.json", "*.json5"],
+      files: ["*.json", "*.json5", "*.jsonc"],
       parser: "jsonc-eslint-parser",
     },
   ],

--- a/lib/configs/base.ts
+++ b/lib/configs/base.ts
@@ -2,7 +2,7 @@ export = {
     plugins: ["jsonc"],
     overrides: [
         {
-            files: ["*.json", "*.json5"],
+            files: ["*.json", "*.json5", "*.jsonc"],
             parser: require.resolve("jsonc-eslint-parser"),
             rules: {
                 // ESLint core rules known to cause problems with JSON.


### PR DESCRIPTION
close #126