### PR TITLE
Minor doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ This plugin provides configs:
 - `plugin:jsonc/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 - `plugin:jsonc/all` ... Enables all rules. It's meant for testing, not for production use because it changes with every minor and major version of the plugin. Use it at your own risk.
 
+This plugin will parse `.json`, `.jsonc` and `.json5` by default using the configuration provided by the plugin (unless you already have a parser configured - see below).
+
 See [the rule list](https://ota-meshi.github.io/eslint-plugin-jsonc/rules/) to get the `rules` that this plugin provides.
 
 #### Parser Configuration
 
-If you have specified a parser, you need to configure a parser for `.json`.
+If you have already specified a parser in your `.eslintrc`, you will also need to manually configure the parser for JSON files (your parser config takes priority over that defined by `extends` shared configs).
 
 For example, if you are using the `"@babel/eslint-parser"`, configure it as follows:
 
@@ -139,17 +141,6 @@ module.exports = {
   ],
   // ...
 };
-```
-
-### Running ESLint from the command line
-
-If you want to run `eslint` from the command line, make sure you include the `.json` extension using [the `--ext` option](https://eslint.org/docs/user-guide/configuring#specifying-file-extensions-to-lint) or a glob pattern, because ESLint targets only `.js` files by default.
-
-Examples:
-
-```bash
-eslint --ext .js,.json src
-eslint "src/**/*.{js,json}"
 ```
 
 ## :computer: Editor Integrations

--- a/docs/rules/auto.md
+++ b/docs/rules/auto.md
@@ -15,10 +15,9 @@ since: "v0.8.0"
 
 Automatically apply jsonc rules similar to your configured ESLint core rules to JSON.
 
-This rule checks the ESLint core rules you are already using in your configuration and internally turns ON the [Extension Rules](./README.md#extension-rules) provided by this plugin.
+This rule checks the ESLint core rules you are already using in your configuration and automatically turns ON the equivalent [Extension Rules](./README.md#extension-rules) provided by this plugin.
 
-If you already have the `jsonc/*` rule turned ON, that rule will not apply. Instead, that rule will check your JSON.
-The rules contained in the sharable configuration work as well. If you use the `"plugin:jsonc/recommended-with-json"` configuration, the `auto` rule will not turn ON the `jsonc/comma-dangle` rule even if you were using the `comma-dangle` rule.
+If you have already configured a particular jsonc rule, either explicitly or via a shared configuration, then that will take precedence over `jsonc/auto`. For example, if you use the `"plugin:jsonc/recommended-with-json"` configuration, the `auto` rule will not turn ON the `jsonc/comma-dangle` rule even if the `comma-dangle` rule is enabled in your core ESLint config.
 
 ## :wrench: Options
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -101,9 +101,9 @@ Example **.vscode/settings.json**:
 
 ## :question: FAQ
 
-### How to parse files other than `.json` and `.json5`?
+### How to parse files other than `.json`, `.jsonc` and `.json5`?
 
-This plugin will parse `.json` and `.json5` using the configuration provided by the plugin.
+This plugin will parse `.json`, `.jsonc` and `.json5` using the configuration provided by the plugin.
 To parse other extensions, you need to add a setting to your configuration.
 
 Example **.eslintrc.js**:

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -45,11 +45,13 @@ This plugin provides configs:
 - `plugin:jsonc/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 - `plugin:jsonc/all` ... Enables all rules. It's meant for testing, not for production use because it changes with every minor and major version of the plugin. Use it at your own risk.
 
+This plugin will parse `.json`, `.jsonc` and `.json5` by default using the configuration provided by the plugin (unless you already have a parser configured - see below).
+
 See [the rule list](../rules/README.md) to get the `rules` that this plugin provides.
 
 #### Parser Configuration
 
-If you have specified a parser, you need to configure a parser for `.json`.
+If you have already specified a parser in your `.eslintrc`, you will also need to manually configure the parser for JSON files (your parser config takes priority over that defined by `extends` shared configs).
 
 For example, if you are using the `"@babel/eslint-parser"`, configure it as follows:
 
@@ -68,17 +70,6 @@ module.exports = {
   ],
   // ...
 };
-```
-
-### Running ESLint from the command line
-
-If you want to run `eslint` from the command line, make sure you include the `.json` extension using [the `--ext` option](https://eslint.org/docs/user-guide/configuring#specifying-file-extensions-to-lint) or a glob pattern, because ESLint targets only `.js` files by default.
-
-Examples:
-
-```bash
-eslint --ext .js,.json src
-eslint "src/**/*.{js,json}"
 ```
 
 ## :computer: Editor Integrations


### PR DESCRIPTION
This is a great plugin - thanks for all your work on this. I just recently started using this plugin for linting JSON files and found a couple of areas of the documentation slightly confusing.

In particular, I didn't understand the docs for the `auto` rule so ended up looking at the source to clarify what it's supposed to do.

The other thing that I found confusing was understanding what ESLint config was required in order to parse JSON files. The docs suggested that ESLint would only check files if they're specified on the command-line, or if there's an override configured for the parser, however it does pick up JSON files automatically.

This PR just consists of a couple of minor doc updates for clarity, and removes an out-of-date section, which will hopefully save some confusion for others.