### PR TITLE
fix: error using all without `sort-array-values` config

### DIFF
--- a/lib/configs/all.ts
+++ b/lib/configs/all.ts
@@ -6,6 +6,7 @@ const baseExtend =
 
 const all: Record<string, string> = {}
 for (const rule of rules) {
+    if (rule.meta.docs.ruleId === "jsonc/sort-array-values") continue
     all[rule.meta.docs.ruleId] = "error"
 }
 


### PR DESCRIPTION
When using `plugin:jsonc/all` config and `sort-arrary-value` is not configured, the following error alert will appear.

```
Configuration for rule "jsonc/sort-array-values" is invalid:
        Value [] should NOT have fewer than 1 items.
```

Considering that this item is useless without detailed configuration, I just exclude it from `all`.