### PR TITLE
Fix wrong auto-config when nesting config with markdown in `jsonc/auto` rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@
 /tests-integrations/fixtures/eslint-plugin-markdown/test.md
 /tests-integrations/fixtures/vue-eslint-parser-option/test.json
 /tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
+/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/test.md
 /assets
 /index.d.ts
 !/.github

--- a/.eslintignore
+++ b/.eslintignore
@@ -10,6 +10,7 @@
 /tests/fixtures/**/*.json
 /tests-integrations/fixtures/eslint-plugin-markdown/test.md
 /tests-integrations/fixtures/vue-eslint-parser-option/test.json
+/tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
 /assets
 /index.d.ts
 !/.github

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ dist
 /typings/eslint/lib
 /dist-ts
 /index.d.ts
+/tests-integrations/fixtures/**/package-lock.json
 
 # docs
 /404.html

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "npm run test:base",
     "test:nyc": "nyc --reporter=lcov npm run test:base",
     "test:debug": "mocha --require ts-node/register/transpile-only \"tests/lib/**/*.ts\" --reporter dot",
-    "pretest:integrations": "npm run build:ts",
+    "pretest:integrations": "npm run build:ts && npm pack",
     "test:integrations": "mocha --require ts-node/register \"tests-integrations/lib/**/*.ts\" --reporter dot --timeout 120000",
     "update": "ts-node --transpile-only ./tools/update.ts && npm run eslint-fix && npm run test:nyc",
     "update-only": "ts-node --transpile-only ./tools/update.ts",

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/.eslintrc.json
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "root": true,
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2015
+  },
+  "extends": [
+    "plugin:markdown/recommended"
+  ],
+  "rules": {
+    "quotes": ["error", "single"]
+  },
+  "overrides": [
+    {
+      "files": ["*.json"],
+      "extends": [
+        "plugin:jsonc/recommended-with-json"
+      ],
+      "rules": { "jsonc/auto": "error" }
+    }
+  ]
+}

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/package.json
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^8.19.0",
+    "eslint": "^6.8.0",
     "eslint-plugin-jsonc": "file:../../../eslint-plugin-jsonc-2.3.0.tgz",
     "eslint-plugin-markdown": "^2.2.1"
   }

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/test.md
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest-for-v6/test.md
@@ -1,0 +1,5 @@
+```json
+{
+    "quotes": 'value'
+}
+```

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest/.eslintrc.json
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "root": true,
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2015
+  },
+  "extends": [
+    "plugin:markdown/recommended"
+  ],
+  "rules": {
+    "quotes": ["error", "single"]
+  },
+  "overrides": [
+    {
+      "files": ["*.json"],
+      "extends": [
+        "plugin:jsonc/recommended-with-json"
+      ],
+      "rules": { "jsonc/auto": "error" }
+    }
+  ]
+}

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest/package.json
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-for-eslint-plugin-jsonc-with-md",
+  "name": "test-for-eslint-plugin-jsonc-with-md-nest",
   "private": true,
   "version": "1.0.0",
   "description": "",
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^8.0.0",
+    "eslint": "^8.19.0",
     "eslint-plugin-jsonc": "file:../../../eslint-plugin-jsonc-2.3.0.tgz",
     "eslint-plugin-markdown": "^2.0.0-0"
   }

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
@@ -1,0 +1,6 @@
+
+```json
+{
+    "quotes": 'value'
+}
+```

--- a/tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
+++ b/tests-integrations/fixtures/eslint-plugin-markdown-nest/test.md
@@ -1,6 +1,13 @@
-
 ```json
 {
     "quotes": 'value'
 }
 ```
+
+````md
+```json
+{
+  "quotes": 'value'
+}
+```
+````

--- a/tests-integrations/fixtures/eslint-plugin-markdown/.npmrc
+++ b/tests-integrations/fixtures/eslint-plugin-markdown/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/tests-integrations/fixtures/eslint-plugin-markdown/package.json
+++ b/tests-integrations/fixtures/eslint-plugin-markdown/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "eslint": "^8.0.0",
     "eslint-plugin-jsonc": "file:../../../eslint-plugin-jsonc-2.3.0.tgz",
-    "eslint-plugin-markdown": "^2.0.0-0"
+    "eslint-plugin-markdown": "^2.2.1"
   }
 }

--- a/tests-integrations/fixtures/vue-eslint-parser-option/.npmrc
+++ b/tests-integrations/fixtures/vue-eslint-parser-option/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/tests-integrations/fixtures/vue-eslint-parser-option/package.json
+++ b/tests-integrations/fixtures/vue-eslint-parser-option/package.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "devDependencies": {
         "eslint": "^8.0.0",
-        "vue-eslint-parser": "^9.0.0",
-        "eslint-plugin-jsonc": "file:../../../"
+        "eslint-plugin-jsonc": "file:../../../eslint-plugin-jsonc-2.3.0.tgz",
+        "vue-eslint-parser": "^9.0.0"
     }
 }

--- a/tests-integrations/lib/eslint-plugin-markdown-nest-for-v6.ts
+++ b/tests-integrations/lib/eslint-plugin-markdown-nest-for-v6.ts
@@ -1,0 +1,68 @@
+import cp from "child_process"
+import assert from "assert"
+import path from "path"
+import { version } from "../../package.json"
+import type { ESLint } from "eslint"
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const TEST_CWD = path.join(
+    __dirname,
+    "../fixtures/eslint-plugin-markdown-nest-for-v6",
+)
+const ESLINT = path.join(TEST_CWD, `./node_modules/.bin/eslint`)
+
+describe("Integration with eslint-plugin-markdown with nesting config with eslint v6", () => {
+    let originalCwd: string
+
+    before(() => {
+        originalCwd = process.cwd()
+        // To test ESLint v6, remove `@eslint/eslintrc` module in the root.
+        cp.execSync(`npx rimraf node_modules/@eslint/eslintrc`, {
+            stdio: "inherit",
+        })
+
+        process.chdir(TEST_CWD)
+        cp.execSync(`npm i -D ../../../eslint-plugin-jsonc-${version}.tgz`, {
+            stdio: "inherit",
+        })
+        cp.execSync("npm i", { stdio: "inherit" })
+    })
+    after(() => {
+        process.chdir(originalCwd)
+
+        // `npm install` to get the removed module back.
+        cp.execSync(`npm i`, {
+            stdio: "inherit",
+        })
+    })
+
+    it(`should lint errors`, () => {
+        try {
+            const res = cp.execSync(
+                `${ESLINT} "./test.md" --format json --ext .md,.json`,
+            )
+            console.log(`${res}`)
+        } catch (e: any) {
+            const results: ESLint.LintResult[] = JSON.parse(`${e.stdout}`)
+            assert.deepStrictEqual(
+                results[0].messages.map((message) => ({
+                    message: message.message,
+                    ruleId: message.ruleId,
+                    line: message.line,
+                })),
+                [
+                    {
+                        message: "Strings must use doublequote.",
+                        ruleId: "jsonc/quotes",
+                        line: 3,
+                    },
+                ],
+            )
+            return
+        }
+        assert.fail("Expect error")
+    })
+})

--- a/tests-integrations/lib/eslint-plugin-markdown-nest.ts
+++ b/tests-integrations/lib/eslint-plugin-markdown-nest.ts
@@ -1,0 +1,69 @@
+import cp from "child_process"
+import assert from "assert"
+import path from "path"
+import { version } from "../../package.json"
+import type { ESLint } from "eslint"
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const TEST_CWD = path.join(__dirname, "../fixtures/eslint-plugin-markdown-nest")
+const ESLINT = path.join(TEST_CWD, `./node_modules/.bin/eslint`)
+
+describe("Integration with eslint-plugin-markdown with nesting config", () => {
+    let originalCwd: string
+
+    before(() => {
+        originalCwd = process.cwd()
+        // To test ESLint v6, remove `@eslint/eslintrc` module in the root.
+        cp.execSync(`npx rimraf node_modules/@eslint/eslintrc`, {
+            stdio: "inherit",
+        })
+
+        process.chdir(TEST_CWD)
+        cp.execSync(`npm i -D ../../../eslint-plugin-jsonc-${version}.tgz`, {
+            stdio: "inherit",
+        })
+    })
+    after(() => {
+        process.chdir(originalCwd)
+
+        // `npm install` to get the removed module back.
+        cp.execSync(`npm i`, {
+            stdio: "inherit",
+        })
+    })
+
+    for (const eslintVersion of [6, 7, 8]) {
+        it(`should lint errors with ESLint v${eslintVersion}`, () => {
+            cp.execSync(`npm i -D eslint@${eslintVersion}`, {
+                stdio: "inherit",
+            })
+            cp.execSync("npm i", { stdio: "inherit" })
+
+            try {
+                const res = cp.execSync(
+                    `${ESLINT} "./test.md" --format json --ext .md,.json`,
+                )
+                console.log(`${res}`)
+            } catch (e: any) {
+                const results: ESLint.LintResult[] = JSON.parse(`${e.stdout}`)
+                assert.deepStrictEqual(
+                    results[0].messages.map((message) => ({
+                        message: message.message,
+                        ruleId: message.ruleId,
+                    })),
+                    [
+                        {
+                            message: "Strings must use doublequote.",
+                            ruleId: "jsonc/quotes",
+                        },
+                    ],
+                )
+                return
+            }
+            assert.fail("Expect error")
+        })
+    }
+})

--- a/tests-integrations/lib/eslint-plugin-markdown-nest.ts
+++ b/tests-integrations/lib/eslint-plugin-markdown-nest.ts
@@ -16,11 +16,6 @@ describe("Integration with eslint-plugin-markdown with nesting config", () => {
 
     before(() => {
         originalCwd = process.cwd()
-        // To test ESLint v6, remove `@eslint/eslintrc` module in the root.
-        cp.execSync(`npx rimraf node_modules/@eslint/eslintrc`, {
-            stdio: "inherit",
-        })
-
         process.chdir(TEST_CWD)
         cp.execSync(`npm i -D ../../../eslint-plugin-jsonc-${version}.tgz`, {
             stdio: "inherit",
@@ -28,14 +23,9 @@ describe("Integration with eslint-plugin-markdown with nesting config", () => {
     })
     after(() => {
         process.chdir(originalCwd)
-
-        // `npm install` to get the removed module back.
-        cp.execSync(`npm i`, {
-            stdio: "inherit",
-        })
     })
 
-    for (const eslintVersion of [6, 7, 8]) {
+    for (const eslintVersion of [7, 8]) {
         it(`should lint errors with ESLint v${eslintVersion}`, () => {
             cp.execSync(`npm i -D eslint@${eslintVersion}`, {
                 stdio: "inherit",
@@ -53,11 +43,18 @@ describe("Integration with eslint-plugin-markdown with nesting config", () => {
                     results[0].messages.map((message) => ({
                         message: message.message,
                         ruleId: message.ruleId,
+                        line: message.line,
                     })),
                     [
                         {
                             message: "Strings must use doublequote.",
                             ruleId: "jsonc/quotes",
+                            line: 3,
+                        },
+                        {
+                            message: "Strings must use doublequote.",
+                            ruleId: "jsonc/quotes",
+                            line: 10,
                         },
                     ],
                 )

--- a/tests-integrations/lib/eslint-plugin-markdown.ts
+++ b/tests-integrations/lib/eslint-plugin-markdown.ts
@@ -1,15 +1,14 @@
 import cp from "child_process"
 import assert from "assert"
 import path from "path"
-import plugin from "../../lib/index"
+import { version } from "../../package.json"
 
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 
 const TEST_CWD = path.join(__dirname, "../fixtures/eslint-plugin-markdown")
-
-const ESLINT = path.join(TEST_CWD, `./node_modules/eslint`)
+const ESLINT = path.join(TEST_CWD, `./node_modules/.bin/eslint`)
 
 describe("Integration with eslint-plugin-markdown", () => {
     let originalCwd: string
@@ -17,34 +16,30 @@ describe("Integration with eslint-plugin-markdown", () => {
     before(() => {
         originalCwd = process.cwd()
         process.chdir(TEST_CWD)
+        cp.execSync(`npm i -D ../../../eslint-plugin-jsonc-${version}.tgz`, {
+            stdio: "inherit",
+        })
         cp.execSync("npm i", { stdio: "inherit" })
     })
     after(() => {
         process.chdir(originalCwd)
     })
 
-    it("should lint errors", async () => {
-        /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- test */
-        // @ts-ignore
-        const eslint = require(ESLINT)
-        if (!eslint.ESLint) {
+    it("should lint errors", () => {
+        try {
+            const res = cp.execSync(`${ESLINT} "./test.md" --format json`)
+            console.log(`${res}`)
+        } catch (e: any) {
+            const results = JSON.parse(`${e.stdout}`)
+
+            assert.strictEqual(results.length, 1)
+            assert.strictEqual(results[0].messages.length, 1)
+            assert.strictEqual(
+                results[0].messages[0].message,
+                "[jsonc/array-bracket-newline] There should be no linebreak before ']'.",
+            )
             return
         }
-        /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- test */
-        const engine = new eslint.ESLint({
-            cwd: TEST_CWD,
-            extensions: [".js", ".json", ".yaml"],
-            plugins: {
-                "eslint-plugin-jsonc": plugin,
-            },
-        })
-        const results = await engine.lintFiles(["./test.md"])
-
-        assert.strictEqual(results.length, 1)
-        assert.strictEqual(results[0].messages.length, 1)
-        assert.strictEqual(
-            results[0].messages[0].message,
-            "[jsonc/array-bracket-newline] There should be no linebreak before ']'.",
-        )
+        assert.fail("Expect error")
     })
 })

--- a/tests-integrations/lib/vue-eslint-parser-option.ts
+++ b/tests-integrations/lib/vue-eslint-parser-option.ts
@@ -1,15 +1,14 @@
 import cp from "child_process"
 import assert from "assert"
 import path from "path"
-import plugin from "../../lib/index"
+import { version } from "../../package.json"
 
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 
 const TEST_CWD = path.join(__dirname, "../fixtures/vue-eslint-parser-option")
-
-const ESLINT = path.join(TEST_CWD, `./node_modules/eslint`)
+const ESLINT = path.join(TEST_CWD, `./node_modules/.bin/eslint`)
 
 describe("Integration with vue-eslint-parser with option", () => {
     let originalCwd: string
@@ -17,34 +16,30 @@ describe("Integration with vue-eslint-parser with option", () => {
     before(() => {
         originalCwd = process.cwd()
         process.chdir(TEST_CWD)
+        cp.execSync(`npm i -D ../../../eslint-plugin-jsonc-${version}.tgz`, {
+            stdio: "inherit",
+        })
         cp.execSync("npm i", { stdio: "inherit" })
     })
     after(() => {
         process.chdir(originalCwd)
     })
 
-    it("should lint errors", async () => {
-        /* eslint-disable  @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- test */
-        // @ts-ignore
-        const eslint = require(ESLINT)
-        if (!eslint.ESLint) {
+    it("should lint errors", () => {
+        try {
+            const res = cp.execSync(`${ESLINT} "./test.json" --format json`)
+            console.log(`${res}`)
+        } catch (e: any) {
+            const results = JSON.parse(`${e.stdout}`)
+
+            assert.strictEqual(results.length, 1)
+            assert.strictEqual(results[0].messages.length, 1)
+            assert.strictEqual(
+                results[0].messages[0].message,
+                "Expected indentation of 4 spaces but found 0.",
+            )
             return
         }
-        /* eslint-enable  @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- test */
-        const engine = new eslint.ESLint({
-            cwd: TEST_CWD,
-            extensions: [".js", ".json", ".yaml"],
-            plugins: {
-                "eslint-plugin-jsonc": plugin,
-            },
-        })
-        const results = await engine.lintFiles(["./test.json"])
-
-        assert.strictEqual(results.length, 1)
-        assert.strictEqual(results[0].messages.length, 1)
-        assert.strictEqual(
-            results[0].messages[0].message,
-            "Expected indentation of 4 spaces but found 0.",
-        )
+        assert.fail("Expect error")
     })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "paths": {
       "*": ["typings/*"]
     },
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": [
     "lib/**/*",


### PR DESCRIPTION

fixes #178