### PR TITLE
Properly exclude "off" rules in jsonc/auto

### DIFF
--- a/lib/utils/get-auto-jsonc-rules-config.ts
+++ b/lib/utils/get-auto-jsonc-rules-config.ts
@@ -134,8 +134,11 @@ export function getAutoConfig(filename: string): {
             const jsoncName = getJsoncRule(ruleName)
             if (jsoncName && !config.rules[jsoncName]) {
                 const entry = config.rules[ruleName]
-                if (entry && entry !== "off") {
-                    autoConfig[jsoncName] = entry
+                if (entry) {
+                    const severity = Array.isArray(entry) ? entry[0] : entry
+                    if (severity !== "off" && severity !== 0) {
+                        autoConfig[jsoncName] = entry
+                    }
                 }
             }
         }

--- a/tests/fixtures/auto/test03/.eslintrc.json
+++ b/tests/fixtures/auto/test03/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "extends": ["eslint:all"],
+  "rules": {
+    "indent": ["off", 4]
+  }
+}

--- a/tests/lib/rules/auto.ts
+++ b/tests/lib/rules/auto.ts
@@ -24,6 +24,12 @@ tester.run("auto", rule as any, {
 </i18n>`,
             parser: require.resolve("vue-eslint-parser"),
         },
+        {
+            filename: path.join(ROOT_DIR, "test03", "test.json"),
+            code: `{
+                "foo": "bar"
+            }`,
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
`jsonc/auto` did not properly detect if a core rule is turned off

```jsonc
{
    "rules": {
        "indent": "off", // ok
        "indent": 0, // not detected
        "indent": ["off", 4], // not detected
        "indent": [0, 4] // not detected
    }
}
```

This PR fixes this