### PR TITLE
disable core rule "no-unused-vars"

### DIFF
--- a/.changeset/smart-bottles-beam.md
+++ b/.changeset/smart-bottles-beam.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-jsonc": minor
+---
+
+disable `no-unused-vars` in base config

--- a/lib/configs/base.ts
+++ b/lib/configs/base.ts
@@ -8,6 +8,7 @@ export = {
         // ESLint core rules known to cause problems with JSON.
         strict: "off",
         "no-unused-expressions": "off",
+        "no-unused-vars": "off",
       },
     },
   ],


### PR DESCRIPTION
Same problem as in https://github.com/ota-meshi/eslint-plugin-yml/issues/204, same fix as in https://github.com/ota-meshi/eslint-plugin-yml/issues/205

example.jsonc
```json
/* global test */
"data"
```
triggers `1:11  error  'test' is defined but never used. Allowed unused vars must match /^_/u  no-unused-vars`