### PR TITLE
keys sorting rule hint

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -16,6 +16,9 @@ since: "v0.1.0"
 
 This rule checks property definitions of object and verifies that all properties are sorted alphabetically or specified order.
 
+ℹ️ To fully sort long files, you may need to run ESLint's `--fix` option multiple times.
+The rule sorts keys incrementally, and ESLint limits the number of fixes to 10 per run.
+
 <eslint-code-block fix>
 
 <!-- eslint-skip -->


### PR DESCRIPTION
Add information about needing to repeat `--fix` many times to sort keys as mentioned on #257