### PR TITLE
chore: add JSONC AST node types to RuleListener nodes

### DIFF
--- a/lib/rules/key-name-casing.ts
+++ b/lib/rules/key-name-casing.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import type { CasingKind } from "../utils/casing";
 import { getChecker, allowedCaseOptions } from "../utils/casing";
@@ -91,7 +90,7 @@ export default createRule("key-name-casing", {
     }
 
     return {
-      JSONProperty(node: AST.JSONProperty) {
+      JSONProperty(node) {
         const name =
           node.key.type === "JSONLiteral" && typeof node.key.value === "string"
             ? node.key.value

--- a/lib/rules/no-bigint-literals.ts
+++ b/lib/rules/no-bigint-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -22,7 +21,7 @@ export default createRule("no-bigint-literals", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (node.bigint != null) {
           context.report({
             loc: node.loc,

--- a/lib/rules/no-binary-expression.ts
+++ b/lib/rules/no-binary-expression.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { getStaticJSONValue } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
@@ -26,7 +25,7 @@ export default createRule("no-binary-expression", {
     }
 
     return {
-      JSONBinaryExpression(node: AST.JSONBinaryExpression) {
+      JSONBinaryExpression(node) {
         context.report({
           loc: node.loc,
           messageId: "disallow",

--- a/lib/rules/no-binary-numeric-literals.ts
+++ b/lib/rules/no-binary-numeric-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -25,7 +24,7 @@ export default createRule("no-binary-numeric-literals", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (
           typeof node.value === "number" &&
           binaryNumericLiteralPattern.test(node.raw)

--- a/lib/rules/no-escape-sequence-in-identifier.ts
+++ b/lib/rules/no-escape-sequence-in-identifier.ts
@@ -24,7 +24,7 @@ export default createRule("no-escape-sequence-in-identifier", {
       return {};
     }
     return {
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         verify(node);
       },
     };
@@ -32,7 +32,7 @@ export default createRule("no-escape-sequence-in-identifier", {
     /**
      * verify
      */
-    function verify(node: AST.JSONNode) {
+    function verify(node: AST.JSONIdentifier) {
       const escapeMatcher = new PatternMatcher(/\\u\{[\dA-Fa-f]+\}|\\u\d{4}/gu);
       const text = sourceCode.text.slice(...node.range);
       for (const match of escapeMatcher.execAll(text)) {

--- a/lib/rules/no-hexadecimal-numeric-literals.ts
+++ b/lib/rules/no-hexadecimal-numeric-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -25,7 +24,7 @@ export default createRule("no-hexadecimal-numeric-literals", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (
           typeof node.value === "number" &&
           hexadecimalNumericLiteralPattern.test(node.raw)

--- a/lib/rules/no-infinity.ts
+++ b/lib/rules/no-infinity.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { isNumberIdentifier } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
@@ -23,7 +22,7 @@ export default createRule("no-infinity", {
       return {};
     }
     return {
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         if (!isNumberIdentifier(node)) {
           return;
         }

--- a/lib/rules/no-nan.ts
+++ b/lib/rules/no-nan.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { isNumberIdentifier } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
@@ -23,7 +22,7 @@ export default createRule("no-nan", {
       return {};
     }
     return {
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         if (!isNumberIdentifier(node)) {
           return;
         }

--- a/lib/rules/no-number-props.ts
+++ b/lib/rules/no-number-props.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -23,7 +22,7 @@ export default createRule("no-number-props", {
       return {};
     }
     return {
-      JSONProperty(node: AST.JSONProperty) {
+      JSONProperty(node) {
         if (node.key.type !== "JSONLiteral") {
           return;
         }

--- a/lib/rules/no-numeric-separators.ts
+++ b/lib/rules/no-numeric-separators.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -23,7 +22,7 @@ export default createRule("no-numeric-separators", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (typeof node.value !== "number") {
           return;
         }

--- a/lib/rules/no-octal-numeric-literals.ts
+++ b/lib/rules/no-octal-numeric-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -25,7 +24,7 @@ export default createRule("no-octal-numeric-literals", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (
           typeof node.value === "number" &&
           octalNumericLiteralPattern.test(node.raw)

--- a/lib/rules/no-plus-sign.ts
+++ b/lib/rules/no-plus-sign.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -23,7 +22,7 @@ export default createRule("no-plus-sign", {
       return {};
     }
     return {
-      JSONUnaryExpression(node: AST.JSONUnaryExpression) {
+      JSONUnaryExpression(node) {
         if (node.operator === "+") {
           const operator = sourceCode.getFirstToken(
             node as any,

--- a/lib/rules/no-regexp-literals.ts
+++ b/lib/rules/no-regexp-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -22,7 +21,7 @@ export default createRule("no-regexp-literals", {
       return {};
     }
     return {
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (node.regex) {
           context.report({
             loc: node.loc,

--- a/lib/rules/no-template-literals.ts
+++ b/lib/rules/no-template-literals.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
 
@@ -23,7 +22,7 @@ export default createRule("no-template-literals", {
       return {};
     }
     return {
-      JSONTemplateLiteral(node: AST.JSONTemplateLiteral) {
+      JSONTemplateLiteral(node) {
         context.report({
           loc: node.loc,
           messageId: "unexpected",

--- a/lib/rules/no-undefined-value.ts
+++ b/lib/rules/no-undefined-value.ts
@@ -1,4 +1,3 @@
-import type { AST } from "jsonc-eslint-parser";
 import { isUndefinedIdentifier } from "jsonc-eslint-parser";
 import { createRule } from "../utils";
 import { getSourceCode } from "eslint-compat-utils";
@@ -23,7 +22,7 @@ export default createRule("no-undefined-value", {
       return {};
     }
     return {
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         if (!isUndefinedIdentifier(node)) {
           return;
         }

--- a/lib/rules/no-unicode-codepoint-escapes.ts
+++ b/lib/rules/no-unicode-codepoint-escapes.ts
@@ -24,15 +24,15 @@ export default createRule("no-unicode-codepoint-escapes", {
       return {};
     }
     return {
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         verify(node);
       },
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (typeof node.value === "string") {
           verify(node);
         }
       },
-      JSONTemplateElement(node: AST.JSONTemplateElement) {
+      JSONTemplateElement(node) {
         verify(node);
       },
     };

--- a/lib/rules/sort-array-values.ts
+++ b/lib/rules/sort-array-values.ts
@@ -472,7 +472,7 @@ export default createRule("sort-array-values", {
     }
 
     return {
-      JSONArrayExpression(node: AST.JSONArrayExpression) {
+      JSONArrayExpression(node) {
         const data = new JSONArrayData(node, sourceCode);
         const option = parsedOptions.find((o) => o.isTargetArray(data));
         if (!option) {

--- a/lib/rules/sort-keys.ts
+++ b/lib/rules/sort-keys.ts
@@ -521,7 +521,7 @@ export default createRule("sort-keys", {
     }
 
     return {
-      JSONObjectExpression(node: AST.JSONObjectExpression) {
+      JSONObjectExpression(node) {
         const data = new JSONObjectData(node);
         const option = parsedOptions.find((o) => o.isTargetObject(data));
         if (!option) {

--- a/lib/rules/valid-json-number.ts
+++ b/lib/rules/valid-json-number.ts
@@ -50,7 +50,7 @@ export default createRule("valid-json-number", {
       return {} as RuleListener;
     }
     return {
-      JSONUnaryExpression(node: AST.JSONUnaryExpression) {
+      JSONUnaryExpression(node) {
         if (node.argument.type === "JSONIdentifier") {
           return;
         }
@@ -83,7 +83,7 @@ export default createRule("valid-json-number", {
           });
         }
       },
-      JSONLiteral(node: AST.JSONLiteral) {
+      JSONLiteral(node) {
         if (typeof node.value !== "number") {
           return;
         }
@@ -130,7 +130,7 @@ export default createRule("valid-json-number", {
           });
         }
       },
-      JSONIdentifier(node: AST.JSONIdentifier) {
+      JSONIdentifier(node) {
         if (!isNumberIdentifier(node)) {
           return;
         }

--- a/lib/rules/vue-custom-block/no-parsing-error.ts
+++ b/lib/rules/vue-custom-block/no-parsing-error.ts
@@ -67,7 +67,8 @@ function errorReportVisitor(
   return {
     Program(node) {
       context.report({
-        node,
+        // JSONC AST nodes aren't assignable to ESTree AST nodes
+        node: node as never,
         loc,
         message: error.message,
       });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,23 @@
 import type { JSONSchema4 } from "json-schema";
 import type { Rule } from "eslint";
-export interface RuleListener {
-  [key: string]: ((node: never) => void) | undefined;
+import type { AST } from "jsonc-eslint-parser";
+
+export type RuleFunction<Node extends AST.JSONNode = never> = (
+  node: Node,
+) => void;
+
+export type BuiltInRuleListeners = {
+  [Node in AST.JSONNode as Node["type"]]?: RuleFunction<Node>;
+};
+
+export type BuiltInRuleListenerExits = {
+  [Node in AST.JSONNode as `${Node["type"]}:exit`]?: RuleFunction<Node>;
+};
+
+export interface RuleListener
+  extends BuiltInRuleListeners,
+    BuiltInRuleListenerExits {
+  [key: string]: RuleFunction | undefined;
 }
 
 export interface RuleModule {


### PR DESCRIPTION
Augments the `RuleListener` interface with two mappings from `AST.JSONNode["type"]`. One adds the node types under their name (e.g. `"JSONLiteral"`); the other adds them under their name + `":exit"`. We utilize a similar strategy in typescript-eslint: https://github.com/typescript-eslint/typescript-eslint/blob/4c8edcfb7d3cc02d07d2329c87da4377c1cbf969/packages/utils/src/ts-eslint/Rule.ts#L289

Also removes the now-redundant explicit type annotations from the `node` parameters in rule listener functions.

Fixes #268.