### PR TITLE
chore: bring in types from jsonc-eslint-parser

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,24 +1,8 @@
 import type { JSONSchema4 } from "json-schema";
 import type { Rule } from "eslint";
-import type { AST } from "jsonc-eslint-parser";
+import type { RuleListener } from "jsonc-eslint-parser";
 
-export type RuleFunction<Node extends AST.JSONNode = never> = (
-  node: Node,
-) => void;
-
-export type BuiltInRuleListeners = {
-  [Node in AST.JSONNode as Node["type"]]?: RuleFunction<Node>;
-};
-
-export type BuiltInRuleListenerExits = {
-  [Node in AST.JSONNode as `${Node["type"]}:exit`]?: RuleFunction<Node>;
-};
-
-export interface RuleListener
-  extends BuiltInRuleListeners,
-    BuiltInRuleListenerExits {
-  [key: string]: RuleFunction | undefined;
-}
+export { RuleListener };
 
 export interface RuleModule {
   meta: RuleMetaData;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -26,7 +26,7 @@ export function createRule(
       },
     },
     jsoncDefineRule: rule,
-    create(context: Rule.RuleContext): any {
+    create(context: Rule.RuleContext) {
       const sourceCode = getSourceCode(context);
       if (
         typeof sourceCode.parserServices.defineCustomBlocksVisitor ===


### PR DESCRIPTION
Corresponds to https://github.com/ota-meshi/jsonc-eslint-parser/pull/186, as a follow-up to https://github.com/ota-meshi/eslint-plugin-jsonc/pull/269 -> https://github.com/ota-meshi/eslint-plugin-jsonc/pull/269#issuecomment-1770135056.