### PR TITLE
Resolve other plugins as siblings to this plugin

### DIFF
--- a/.changeset/tasty-eels-watch.md
+++ b/.changeset/tasty-eels-watch.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-jsonc": minor
+---
+
+Resolve other plugins relative to this one (as siblings)

--- a/lib/utils/get-auto-jsonc-rules-config/index.ts
+++ b/lib/utils/get-auto-jsonc-rules-config/index.ts
@@ -47,6 +47,8 @@ function getConfigResolver(
         "../../../conf/eslint-recommended.js",
       ),
       eslintAllPath: require.resolve("../../../conf/eslint-all.js"),
+      // other plugins should be resolved as siblings to this one
+      resolvePluginsRelativeTo: resolve(__dirname, "../../../../../"),
     });
     return (configResolvers[cwd] = (filePath: string) => {
       const absolutePath = resolve(cwd, filePath);


### PR DESCRIPTION
**Why do I want this?**
I have a monorepo with the current file structure:
```
apps/
-  app1/
  -  package.json
   .............
-  app127/
  -  package.json
packages/
-  package1/
  -  package.json
   ............
-  package453/
  -  package.json
repotools/
-  central-linter/
  -  package.json
.eslintrc.json
.eslintignore
```

I want to install eslint and all of its configs and plugins into the repotools/central-linter/node_modules. I do not want to install a separate copy of eslint and its plugins in each app/package. Also note that there is no package.json file at the root of the repo because I have lots of issues with npm workspaces.

I also want to keep the .eslintrc.json and .eslintignore files at the root of the monorepo for better IDE integration.

I am able to accomplish all of this except for this `eslint-plugin-jsonc` since this plugin keeps trying to load plugins relative to the root of the monorepo, rather than the `resolvePluginsRelativeTo` that I passed to my central linter.

This PR should modify the behavior of `eslint-plugin-jsonc` to always resolve plugins relative to itself.

P.S. I cannot upgrade to ESLint v9 yet because `nx` and `eslint-plugin-react` does not support ESLint v9 yet.