### PR TITLE
docs: fix load languages

### DIFF
--- a/docs/.vitepress/theme/components/components/EslintPluginEditor.vue
+++ b/docs/.vitepress/theme/components/components/EslintPluginEditor.vue
@@ -79,7 +79,7 @@ export default {
                 rules.map((rule) => [rule.meta.docs.ruleName, rule]),
               ),
               languages: {
-                jsonc: this.jsoncLanguage,
+                x: this.jsoncLanguage,
               },
             },
           },


### PR DESCRIPTION
<img width="1558" height="1140" alt="CleanShot 2026-02-24 at 00 37 11@2x" src="https://github.com/user-attachments/assets/dc091f59-c89a-4826-a21d-5f502650c1c3" />

```
Key "language": Could not find "x" in plugin "jsonc".ESLint(FATAL)
```