### PR TITLE
feat(sort-array-values): add `key` option to sort object arrays by property

### DIFF
--- a/.changeset/sort-array-values-key-option.md
+++ b/.changeset/sort-array-values-key-option.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-jsonc": minor
+---
+
+feat(sort-array-values): add `key` option to sort object arrays by property

--- a/docs/rules/sort-array-values.md
+++ b/docs/rules/sort-array-values.md
@@ -98,12 +98,7 @@ The option receives multiple objects with the following properties:
       - `"desc"` ... Enforce values to be in descending order.
     - `caseSensitive` ... If `true`, enforce values to be in case-sensitive order. Default is `true`.
     - `natural` ... If `true`, enforce values to be in natural order. Default is `false`.
-    - `key` ... Sorts an array of objects by the value of this property. Elements that lack the property are handled by `missingKey`. Default is to compare the element value itself.
-    - `missingKey` ... Defines how to handle elements that lack the `key` property. Used only with `key`.
-      - `"last"` ... Enforce such elements to be at the end of the array. This is default.
-      - `"first"` ... Enforce such elements to be at the start of the array.
-      - `"skip"` ... Ignore such elements when checking the order.
-      - `"error"` ... Report such elements. These are not auto-fixed.
+    - `key` ... Sorts an array of objects by the value of this property. Elements that lack the property are left in place and not reordered. Default is to compare the element value itself.
 - `minValues` ... Specifies the minimum number of values that an array should have in order for the array's unsorted values to produce an error. Default is `2`, which means by default all arrays with unsorted values will result in lint errors.
 
 ## :couple: Related rules

--- a/docs/rules/sort-array-values.md
+++ b/docs/rules/sort-array-values.md
@@ -64,8 +64,7 @@ This rule checks values of array and verifies that values are sorted alphabetica
             "order": [
                 {
                     // Sort object elements by their "name" property
-                    "key": "name",
-                    "order": { "type": "asc" }
+                    "order": { "type": "asc", "key": "name" }
                 },
                 {
                     // Sort any remaining values alphabetically
@@ -84,14 +83,14 @@ The option receives multiple objects with the following properties:
   - Array ... Defines an array of values to enforce the order.
     - String ... Defines the value.
     - Object ... The object has the following properties:
-      - `key` ... Compares object elements by the value of this property. Default is to compare the element value itself.
-      - `valuePattern` ... Defines a pattern to match the value, or the value at `key` when `key` is set. Default is to match all.
+      - `valuePattern` ... Defines a pattern to match the value, or the value at `order.key` when it is set. Default is to match all.
       - `order` ... The object has the following properties:
         - `type`:
           - `"asc"` ... Enforce values to be in ascending order. This is default.
           - `"desc"` ... Enforce values to be in descending order.
         - `caseSensitive` ... If `true`, enforce values to be in case-sensitive order. Default is `true`.
         - `natural` ... If `true`, enforce values to be in natural order. Default is `false`.
+        - `key` ... Sorts an array of objects by the value of this property. Elements that lack the property are left in place and not reordered. Default is to compare the element value itself.
   - Object ... The object has the following properties:
     - `type`:
       - `"asc"` ... Enforce values to be in ascending order. This is default.

--- a/docs/rules/sort-array-values.md
+++ b/docs/rules/sort-array-values.md
@@ -53,6 +53,25 @@ This rule checks values of array and verifies that values are sorted alphabetica
                     "order": { "type": "asc" }
                 }
             ]
+        },
+        {
+            "pathPattern": "^categories\\.\\w+$", // Hits arrays of objects
+            // Sort each array of objects by its "name" property
+            "order": { "type": "asc", "key": "name" }
+        },
+        {
+            "pathPattern": "^items$",
+            "order": [
+                {
+                    // Sort object elements by their "name" property
+                    "key": "name",
+                    "order": { "type": "asc" }
+                },
+                {
+                    // Sort any remaining values alphabetically
+                    "order": { "type": "asc" }
+                }
+            ]
         }
     ]
 }
@@ -65,8 +84,8 @@ The option receives multiple objects with the following properties:
   - Array ... Defines an array of values to enforce the order.
     - String ... Defines the value.
     - Object ... The object has the following properties:
-      - `key` ... Sorts arrays of objects by the value of this property. When set, the matcher targets object elements that have this property, and the value at `key` is used for comparison.
-      - `valuePattern` ... Defines a pattern to match the value (or, when `key` is set, the value at `key`). Default is to match all.
+      - `key` ... Compares object elements by the value of this property. Default is to compare the element value itself.
+      - `valuePattern` ... Defines a pattern to match the value, or the value at `key` when `key` is set. Default is to match all.
       - `order` ... The object has the following properties:
         - `type`:
           - `"asc"` ... Enforce values to be in ascending order. This is default.
@@ -79,70 +98,13 @@ The option receives multiple objects with the following properties:
       - `"desc"` ... Enforce values to be in descending order.
     - `caseSensitive` ... If `true`, enforce values to be in case-sensitive order. Default is `true`.
     - `natural` ... If `true`, enforce values to be in natural order. Default is `false`.
-    - `key` ... Sorts an array of objects by the value of this property. For example, `"key": "name"` sorts the array by each object's `name` value. Non-object elements (and objects missing the property) are handled by `missingKey`.
-    - `missingKey` ... Controls how elements that lack the `key` property are handled. Only relevant when `key` is set.
-      - `"last"` ... Such elements are expected at the end of the array. This is default.
-      - `"first"` ... Such elements are expected at the start of the array.
-      - `"skip"` ... Such elements are ignored when checking the order.
-      - `"error"` ... Such elements are reported (without auto-fix), requiring every element to have the `key` property.
+    - `key` ... Sorts an array of objects by the value of this property. Elements that lack the property are handled by `missingKey`. Default is to compare the element value itself.
+    - `missingKey` ... Defines how to handle elements that lack the `key` property. Used only with `key`.
+      - `"last"` ... Enforce such elements to be at the end of the array. This is default.
+      - `"first"` ... Enforce such elements to be at the start of the array.
+      - `"skip"` ... Ignore such elements when checking the order.
+      - `"error"` ... Report such elements. These are not auto-fixed.
 - `minValues` ... Specifies the minimum number of values that an array should have in order for the array's unsorted values to produce an error. Default is `2`, which means by default all arrays with unsorted values will result in lint errors.
-
-## Sorting object arrays by property key
-
-Use the `key` option to sort an array of objects by the value of a specific property.
-
-<eslint-code-block fix>
-
-<!-- eslint-skip -->
-
-```json5
-/* eslint jsonc/sort-array-values: ['error', { pathPattern: '^categories\\.\\w+$', order: { type: 'asc', key: 'name' } }] */
-{
-    "categories": {
-        "fruits": [
-            /* ✓ GOOD */
-            { "name": "apple" },
-            { "name": "banana" },
-            { "name": "cherry" }
-        ],
-        "vegetables": [
-            /* ✗ BAD */
-            { "name": "carrot" },
-            { "name": "broccoli" },
-            { "name": "asparagus" }
-        ]
-    }
-}
-```
-
-</eslint-code-block>
-
-By default, elements that do not have the `key` property are expected at the end of the array (`missingKey: "last"`). Use `missingKey` to change this to `"first"`, `"skip"` (ignore ordering for those elements), or `"error"` (report any element missing the `key` property).
-
-### Composing with the array form
-
-The array-of-matchers form also accepts `key`, so you can mix object sorting with other rules. For example, sort objects by their `name` property while sorting any remaining values alphabetically:
-
-```json5
-{
-    "jsonc/sort-array-values": ["error",
-        {
-            "pathPattern": "^items$",
-            "order": [
-                {
-                    // Object elements are sorted by their `name` property
-                    "key": "name",
-                    "order": { "type": "asc" }
-                },
-                {
-                    // Remaining (e.g. primitive) values are sorted alphabetically
-                    "order": { "type": "asc" }
-                }
-            ]
-        }
-    ]
-}
-```
 
 ## :couple: Related rules
 

--- a/docs/rules/sort-array-values.md
+++ b/docs/rules/sort-array-values.md
@@ -83,7 +83,7 @@ The option receives multiple objects with the following properties:
   - Array ... Defines an array of values to enforce the order.
     - String ... Defines the value.
     - Object ... The object has the following properties:
-      - `valuePattern` ... Defines a pattern to match the value, or the value at `order.key` when it is set. Default is to match all.
+      - `valuePattern` ... Defines a pattern to match the value, or the value at `order.key`, when defined. Default behavior matches the logic to all values.
       - `order` ... The object has the following properties:
         - `type`:
           - `"asc"` ... Enforce values to be in ascending order. This is default.

--- a/docs/rules/sort-array-values.md
+++ b/docs/rules/sort-array-values.md
@@ -65,7 +65,8 @@ The option receives multiple objects with the following properties:
   - Array ... Defines an array of values to enforce the order.
     - String ... Defines the value.
     - Object ... The object has the following properties:
-      - `valuePattern` ... Defines a pattern to match the value. Default is to match all.
+      - `key` ... Sorts arrays of objects by the value of this property. When set, the matcher targets object elements that have this property, and the value at `key` is used for comparison.
+      - `valuePattern` ... Defines a pattern to match the value (or, when `key` is set, the value at `key`). Default is to match all.
       - `order` ... The object has the following properties:
         - `type`:
           - `"asc"` ... Enforce values to be in ascending order. This is default.
@@ -78,7 +79,70 @@ The option receives multiple objects with the following properties:
       - `"desc"` ... Enforce values to be in descending order.
     - `caseSensitive` ... If `true`, enforce values to be in case-sensitive order. Default is `true`.
     - `natural` ... If `true`, enforce values to be in natural order. Default is `false`.
+    - `key` ... Sorts an array of objects by the value of this property. For example, `"key": "name"` sorts the array by each object's `name` value. Non-object elements (and objects missing the property) are handled by `missingKey`.
+    - `missingKey` ... Controls how elements that lack the `key` property are handled. Only relevant when `key` is set.
+      - `"last"` ... Such elements are expected at the end of the array. This is default.
+      - `"first"` ... Such elements are expected at the start of the array.
+      - `"skip"` ... Such elements are ignored when checking the order.
+      - `"error"` ... Such elements are reported (without auto-fix), requiring every element to have the `key` property.
 - `minValues` ... Specifies the minimum number of values that an array should have in order for the array's unsorted values to produce an error. Default is `2`, which means by default all arrays with unsorted values will result in lint errors.
+
+## Sorting object arrays by property key
+
+Use the `key` option to sort an array of objects by the value of a specific property.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```json5
+/* eslint jsonc/sort-array-values: ['error', { pathPattern: '^categories\\.\\w+$', order: { type: 'asc', key: 'name' } }] */
+{
+    "categories": {
+        "fruits": [
+            /* ✓ GOOD */
+            { "name": "apple" },
+            { "name": "banana" },
+            { "name": "cherry" }
+        ],
+        "vegetables": [
+            /* ✗ BAD */
+            { "name": "carrot" },
+            { "name": "broccoli" },
+            { "name": "asparagus" }
+        ]
+    }
+}
+```
+
+</eslint-code-block>
+
+By default, elements that do not have the `key` property are expected at the end of the array (`missingKey: "last"`). Use `missingKey` to change this to `"first"`, `"skip"` (ignore ordering for those elements), or `"error"` (report any element missing the `key` property).
+
+### Composing with the array form
+
+The array-of-matchers form also accepts `key`, so you can mix object sorting with other rules. For example, sort objects by their `name` property while sorting any remaining values alphabetically:
+
+```json5
+{
+    "jsonc/sort-array-values": ["error",
+        {
+            "pathPattern": "^items$",
+            "order": [
+                {
+                    // Object elements are sorted by their `name` property
+                    "key": "name",
+                    "order": { "type": "asc" }
+                },
+                {
+                    // Remaining (e.g. primitive) values are sorted alphabetically
+                    "order": { "type": "asc" }
+                }
+            ]
+        }
+    ]
+}
+```
 
 ## :couple: Related rules
 

--- a/lib/rules/sort-array-values.ts
+++ b/lib/rules/sort-array-values.ts
@@ -32,13 +32,11 @@ type PatternOption = {
       )[];
   minValues?: number;
 };
-type MissingKeyOption = "skip" | "last" | "first" | "error";
 type OrderObject = {
   type?: OrderTypeOption;
   caseSensitive?: boolean;
   natural?: boolean;
   key?: string;
-  missingKey?: MissingKeyOption;
 };
 type ParsedOption = {
   isTargetArray: (node: JSONArrayData) => boolean;
@@ -46,7 +44,6 @@ type ParsedOption = {
   isValidOrder: Validator;
   orderText: (data: JSONElementData) => string;
   key?: string;
-  missingKey?: MissingKeyOption;
 };
 type Validator = (a: JSONElementData, b: JSONElementData) => boolean;
 
@@ -165,7 +162,6 @@ function buildValidatorFromType(
   insensitive: boolean,
   natural: boolean,
   key?: string,
-  missingKey: MissingKeyOption = "last",
 ): Validator {
   type Compare<T> = ([a, b]: T[]) => boolean;
 
@@ -206,20 +202,9 @@ function buildValidatorFromType(
     if (key) {
       const aVal = a.getValueForKey(key);
       const bVal = b.getValueForKey(key);
-      const aMissing = aVal === undefined;
-      const bMissing = bVal === undefined;
-
-      if (aMissing || bMissing) {
-        // "skip" ignores ordering entirely; "error" never reorders (the
-        // missing element is reported separately and left in place).
-        if (missingKey === "skip" || missingKey === "error") return true;
-        if (aMissing && bMissing) return true;
-        // "first": a missing => a should come first => (a,b) is valid order.
-        // "last" (default): b missing => b should come last => valid order.
-        return missingKey === "first" ? aMissing : bMissing;
-      }
-
-      // Both have the key — compare the extracted values.
+      // Elements missing the key are left in place — they are excluded from
+      // ordering by the caller.
+      if (aVal === undefined || bVal === undefined) return true;
       return compare(aVal, bVal);
     }
 
@@ -240,18 +225,15 @@ function parseOptions(options: UserOptions): ParsedOption[] {
       const insensitive = order.caseSensitive === false;
       const natural = Boolean(order.natural);
       const key = order.key;
-      const missingKey: MissingKeyOption = order.missingKey ?? "last";
 
       return {
         isTargetArray,
-        ignore: () => false,
-        isValidOrder: buildValidatorFromType(
-          type,
-          insensitive,
-          natural,
-          key,
-          missingKey,
-        ),
+        // When sorting by a key, elements missing that key are skipped —
+        // excluded from the sort and left in place.
+        ignore: key
+          ? (v) => v.getValueForKey(key) === undefined
+          : () => false,
+        isValidOrder: buildValidatorFromType(type, insensitive, natural, key),
         orderText(data) {
           const base =
             typeof data.value === "string" || key
@@ -262,7 +244,6 @@ function parseOptions(options: UserOptions): ParsedOption[] {
           return key ? `${base} by '${key}'` : base;
         },
         key,
-        missingKey,
       };
     }
     const parsedOrder: {
@@ -395,12 +376,6 @@ function getJSONPrimitiveType(val: JSONValue) {
 }
 
 const ALLOW_ORDER_TYPES: OrderTypeOption[] = ["asc", "desc"];
-const ALLOW_MISSING_KEY: MissingKeyOption[] = [
-  "skip",
-  "last",
-  "first",
-  "error",
-];
 const ORDER_OBJECT_SCHEMA = {
   type: "object",
   properties: {
@@ -415,9 +390,6 @@ const ORDER_OBJECT_SCHEMA = {
     },
     key: {
       type: "string",
-    },
-    missingKey: {
-      enum: ALLOW_MISSING_KEY,
     },
   },
   additionalProperties: false,
@@ -485,7 +457,6 @@ export default createRule<UserOptions>("sort-array-values", {
         "Expected array values to be in {{orderText}} order. '{{thisValue}}' should be before '{{targetValue}}'.",
       shouldBeAfter:
         "Expected array values to be in {{orderText}} order. '{{thisValue}}' should be after '{{targetValue}}'.",
-      missingKey: "Expected array value to have key '{{key}}' to be sorted.",
     },
     type: "suggestion",
   },
@@ -527,19 +498,6 @@ export default createRule<UserOptions>("sort-array-values", {
       elements: JSONElementData[],
       option: ParsedOption,
     ) {
-      // Report (without fixing) elements that are missing the sort key when
-      // `missingKey: "error"` is set. Ordering is left untouched for these.
-      if (option.key && option.missingKey === "error") {
-        for (const element of elements) {
-          if (element.getValueForKey(option.key) === undefined) {
-            context.report({
-              loc: element.reportLoc,
-              messageId: "missingKey",
-              data: { key: option.key },
-            });
-          }
-        }
-      }
       const sorted = bubbleSort(elements, option);
       const editScript = calcShortestEditScript(elements, sorted);
       for (let index = 0; index < editScript.length; index++) {

--- a/lib/rules/sort-array-values.ts
+++ b/lib/rules/sort-array-values.ts
@@ -25,22 +25,28 @@ type PatternOption = {
     | (
         | string
         | {
+            key?: string;
             valuePattern?: string;
             order?: OrderObject;
           }
       )[];
   minValues?: number;
 };
+type MissingKeyOption = "skip" | "last" | "first" | "error";
 type OrderObject = {
   type?: OrderTypeOption;
   caseSensitive?: boolean;
   natural?: boolean;
+  key?: string;
+  missingKey?: MissingKeyOption;
 };
 type ParsedOption = {
   isTargetArray: (node: JSONArrayData) => boolean;
   ignore: (data: JSONElementData) => boolean;
   isValidOrder: Validator;
   orderText: (data: JSONElementData) => string;
+  key?: string;
+  missingKey?: MissingKeyOption;
 };
 type Validator = (a: JSONElementData, b: JSONElementData) => boolean;
 
@@ -101,6 +107,18 @@ class JSONElementData {
       })
     ).value;
   }
+
+  /**
+   * Get the value of the given property key when this element is an object.
+   * Returns `undefined` for non-object elements or when the key is absent.
+   */
+  public getValueForKey(key: string): JSONValue | undefined {
+    const val = this.value;
+    if (val !== null && typeof val === "object" && !Array.isArray(val)) {
+      return (val as Record<string, JSONValue>)[key];
+    }
+    return undefined;
+  }
 }
 class JSONArrayData {
   public readonly node: AST.JSONArrayExpression;
@@ -131,6 +149,8 @@ function buildValidatorFromType(
   order: OrderTypeOption,
   insensitive: boolean,
   natural: boolean,
+  key?: string,
+  missingKey: MissingKeyOption = "last",
 ): Validator {
   type Compare<T> = ([a, b]: T[]) => boolean;
 
@@ -151,16 +171,44 @@ function buildValidatorFromType(
     const baseCompareValue = compareValue;
     compareValue = (args) => baseCompareValue(args.reverse());
   }
-  return (a: JSONElementData, b: JSONElementData) => {
-    if (typeof a.value === "string" && typeof b.value === "string") {
-      return compareText([a.value, b.value]);
+
+  /**
+   * Compare two resolved values (an element value, or a value extracted by key).
+   */
+  function compare(aVal: JSONValue, bVal: JSONValue): boolean {
+    if (typeof aVal === "string" && typeof bVal === "string") {
+      return compareText([aVal, bVal]);
     }
-    const type = getJSONPrimitiveType(a.value);
-    if (type && type === getJSONPrimitiveType(b.value)) {
-      return compareValue([a.value, b.value]);
+    const type = getJSONPrimitiveType(aVal);
+    if (type && type === getJSONPrimitiveType(bVal)) {
+      return compareValue([aVal, bVal]);
     }
     // Unknown
     return true;
+  }
+
+  return (a: JSONElementData, b: JSONElementData) => {
+    if (key) {
+      const aVal = a.getValueForKey(key);
+      const bVal = b.getValueForKey(key);
+      const aMissing = aVal === undefined;
+      const bMissing = bVal === undefined;
+
+      if (aMissing || bMissing) {
+        // "skip" ignores ordering entirely; "error" never reorders (the
+        // missing element is reported separately and left in place).
+        if (missingKey === "skip" || missingKey === "error") return true;
+        if (aMissing && bMissing) return true;
+        // "first": a missing => a should come first => (a,b) is valid order.
+        // "last" (default): b missing => b should come last => valid order.
+        return missingKey === "first" ? aMissing : bMissing;
+      }
+
+      // Both have the key — compare the extracted values.
+      return compare(aVal, bVal);
+    }
+
+    return compare(a.value, b.value);
   };
 }
 
@@ -176,19 +224,30 @@ function parseOptions(options: UserOptions): ParsedOption[] {
       const type: OrderTypeOption = order.type ?? "asc";
       const insensitive = order.caseSensitive === false;
       const natural = Boolean(order.natural);
+      const key = order.key;
+      const missingKey: MissingKeyOption = order.missingKey ?? "last";
 
       return {
         isTargetArray,
         ignore: () => false,
-        isValidOrder: buildValidatorFromType(type, insensitive, natural),
+        isValidOrder: buildValidatorFromType(
+          type,
+          insensitive,
+          natural,
+          key,
+          missingKey,
+        ),
         orderText(data) {
-          if (typeof data.value === "string") {
-            return `${natural ? "natural " : ""}${
-              insensitive ? "insensitive " : ""
-            }${type}ending`;
-          }
-          return `${type}ending`;
+          const base =
+            typeof data.value === "string" || key
+              ? `${natural ? "natural " : ""}${
+                  insensitive ? "insensitive " : ""
+                }${type}ending`
+              : `${type}ending`;
+          return key ? `${base} by '${key}'` : base;
         },
+        key,
+        missingKey,
       };
     }
     const parsedOrder: {
@@ -202,18 +261,31 @@ function parseOptions(options: UserOptions): ParsedOption[] {
           isValidNestOrder: () => true,
         });
       } else {
+        const itemKey = o.key;
         const valuePattern = o.valuePattern ? new RegExp(o.valuePattern) : null;
         const nestOrder = o.order ?? {};
         const type: OrderTypeOption = nestOrder.type ?? "asc";
         const insensitive = nestOrder.caseSensitive === false;
         const natural = Boolean(nestOrder.natural);
         parsedOrder.push({
-          test: (v) =>
-            valuePattern
+          test: (v) => {
+            if (itemKey) {
+              const keyVal = v.getValueForKey(itemKey);
+              return valuePattern
+                ? keyVal !== undefined && valuePattern.test(String(keyVal))
+                : keyVal !== undefined;
+            }
+            return valuePattern
               ? Boolean(getJSONPrimitiveType(v.value)) &&
-                valuePattern.test(String(v.value))
-              : true,
-          isValidNestOrder: buildValidatorFromType(type, insensitive, natural),
+                  valuePattern.test(String(v.value))
+              : true;
+          },
+          isValidNestOrder: buildValidatorFromType(
+            type,
+            insensitive,
+            natural,
+            itemKey,
+          ),
         });
       }
     }
@@ -308,6 +380,12 @@ function getJSONPrimitiveType(val: JSONValue) {
 }
 
 const ALLOW_ORDER_TYPES: OrderTypeOption[] = ["asc", "desc"];
+const ALLOW_MISSING_KEY: MissingKeyOption[] = [
+  "skip",
+  "last",
+  "first",
+  "error",
+];
 const ORDER_OBJECT_SCHEMA = {
   type: "object",
   properties: {
@@ -319,6 +397,12 @@ const ORDER_OBJECT_SCHEMA = {
     },
     natural: {
       type: "boolean",
+    },
+    key: {
+      type: "string",
+    },
+    missingKey: {
+      enum: ALLOW_MISSING_KEY,
     },
   },
   additionalProperties: false,
@@ -353,6 +437,9 @@ export default createRule<UserOptions>("sort-array-values", {
                     {
                       type: "object",
                       properties: {
+                        key: {
+                          type: "string",
+                        },
                         valuePattern: {
                           type: "string",
                         },
@@ -383,6 +470,7 @@ export default createRule<UserOptions>("sort-array-values", {
         "Expected array values to be in {{orderText}} order. '{{thisValue}}' should be before '{{targetValue}}'.",
       shouldBeAfter:
         "Expected array values to be in {{orderText}} order. '{{thisValue}}' should be after '{{targetValue}}'.",
+      missingKey: "Expected array value to have key '{{key}}' to be sorted.",
     },
     type: "suggestion",
   },
@@ -424,6 +512,19 @@ export default createRule<UserOptions>("sort-array-values", {
       elements: JSONElementData[],
       option: ParsedOption,
     ) {
+      // Report (without fixing) elements that are missing the sort key when
+      // `missingKey: "error"` is set. Ordering is left untouched for these.
+      if (option.key && option.missingKey === "error") {
+        for (const element of elements) {
+          if (element.getValueForKey(option.key) === undefined) {
+            context.report({
+              loc: element.reportLoc,
+              messageId: "missingKey",
+              data: { key: option.key },
+            });
+          }
+        }
+      }
       const sorted = bubbleSort(elements, option);
       const editScript = calcShortestEditScript(elements, sorted);
       for (let index = 0; index < editScript.length; index++) {
@@ -446,8 +547,8 @@ export default createRule<UserOptions>("sort-array-values", {
             loc: edit.a.reportLoc,
             messageId: "shouldBeAfter",
             data: {
-              thisValue: toText(edit.a),
-              targetValue: toText(target),
+              thisValue: toText(edit.a, option.key),
+              targetValue: toText(target, option.key),
               orderText: option.orderText(edit.a),
             },
             *fix(fixer) {
@@ -469,8 +570,8 @@ export default createRule<UserOptions>("sort-array-values", {
             loc: edit.a.reportLoc,
             messageId: "shouldBeBefore",
             data: {
-              thisValue: toText(edit.a),
-              targetValue: toText(target),
+              thisValue: toText(edit.a, option.key),
+              targetValue: toText(target, option.key),
               orderText: option.orderText(edit.a),
             },
             *fix(fixer) {
@@ -549,7 +650,13 @@ export default createRule<UserOptions>("sort-array-values", {
     /**
      * Convert to display text.
      */
-    function toText(data: JSONElementData) {
+    function toText(data: JSONElementData, key?: string) {
+      if (key) {
+        const keyVal = data.getValueForKey(key);
+        if (keyVal !== undefined) {
+          return String(keyVal);
+        }
+      }
       if (getJSONPrimitiveType(data.value)) {
         return String(data.value);
       }

--- a/lib/rules/sort-array-values.ts
+++ b/lib/rules/sort-array-values.ts
@@ -60,6 +60,8 @@ class JSONElementData {
 
   private cached: { value: JSONValue } | null = null;
 
+  private cachedKeyValues: Map<string, JSONValue | undefined> | null = null;
+
   private cachedAround: AroundTarget | null = null;
 
   public get reportLoc() {
@@ -110,14 +112,27 @@ class JSONElementData {
 
   /**
    * Get the value of the given property key when this element is an object.
-   * Returns `undefined` for non-object elements or when the key is absent.
+   * Only the matched property's value is evaluated (and memoized per key),
+   * avoiding a full deep conversion of the whole element. Returns `undefined`
+   * for non-object elements or when the key is absent.
    */
   public getValueForKey(key: string): JSONValue | undefined {
-    const val = this.value;
-    if (val !== null && typeof val === "object" && !Array.isArray(val)) {
-      return (val as Record<string, JSONValue>)[key];
+    const cache = (this.cachedKeyValues ??= new Map());
+    if (cache.has(key)) {
+      return cache.get(key);
     }
-    return undefined;
+    let result: JSONValue | undefined;
+    const node = this.node;
+    if (node && node.type === "JSONObjectExpression") {
+      for (const prop of node.properties) {
+        if (getPropertyName(prop) === key) {
+          result = getStaticJSONValue(prop.value);
+          break;
+        }
+      }
+    }
+    cache.set(key, result);
+    return result;
   }
 }
 class JSONArrayData {
@@ -346,17 +361,17 @@ function parseOptions(options: UserOptions): ParsedOption[] {
       return pathPattern.test(path);
     }
   });
+}
 
-  /**
-   * Gets the property name of the given `Property` node.
-   */
-  function getPropertyName(node: AST.JSONProperty): string {
-    const prop = node.key;
-    if (prop.type === "JSONIdentifier") {
-      return prop.name;
-    }
-    return String(getStaticJSONValue(prop));
+/**
+ * Gets the property name of the given `Property` node.
+ */
+function getPropertyName(node: AST.JSONProperty): string {
+  const prop = node.key;
+  if (prop.type === "JSONIdentifier") {
+    return prop.name;
   }
+  return String(getStaticJSONValue(prop));
 }
 
 /**

--- a/lib/rules/sort-array-values.ts
+++ b/lib/rules/sort-array-values.ts
@@ -25,7 +25,6 @@ type PatternOption = {
     | (
         | string
         | {
-            key?: string;
             valuePattern?: string;
             order?: OrderObject;
           }
@@ -257,12 +256,12 @@ function parseOptions(options: UserOptions): ParsedOption[] {
           isValidNestOrder: () => true,
         });
       } else {
-        const itemKey = o.key;
         const valuePattern = o.valuePattern ? new RegExp(o.valuePattern) : null;
         const nestOrder = o.order ?? {};
         const type: OrderTypeOption = nestOrder.type ?? "asc";
         const insensitive = nestOrder.caseSensitive === false;
         const natural = Boolean(nestOrder.natural);
+        const itemKey = nestOrder.key;
         parsedOrder.push({
           test: (v) => {
             if (itemKey) {
@@ -424,9 +423,6 @@ export default createRule<UserOptions>("sort-array-values", {
                     {
                       type: "object",
                       properties: {
-                        key: {
-                          type: "string",
-                        },
                         valuePattern: {
                           type: "string",
                         },

--- a/tests/lib/rules/sort-array-values.ts
+++ b/tests/lib/rules/sort-array-values.ts
@@ -53,6 +53,57 @@ tester.run("sort-array-values", rule, {
       code: '{"key": [["b"], ["a"], "c"] }',
       options: [{ pathPattern: "^key$", order: { type: "asc" } }],
     },
+    // Sort an array of objects by a property value.
+    {
+      code: '{"categories": [{"name": "a"}, {"name": "b"}, {"name": "c"}] }',
+      options: [
+        { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
+      ],
+    },
+    // `missingKey: "last"` keeps key-less elements at the end.
+    {
+      code: '{"categories": [{"name": "a"}, {"name": "b"}, {"id": 1}] }',
+      options: [
+        {
+          pathPattern: "^categories$",
+          order: { type: "asc", key: "name", missingKey: "last" },
+        },
+      ],
+    },
+    // `missingKey: "first"` keeps key-less elements at the start.
+    {
+      code: '{"categories": [{"id": 1}, {"name": "a"}, {"name": "b"}] }',
+      options: [
+        {
+          pathPattern: "^categories$",
+          order: { type: "asc", key: "name", missingKey: "first" },
+        },
+      ],
+    },
+    // Mixed array: objects sorted by `name`, primitives sorted by value,
+    // without interleaving the two cohorts.
+    {
+      code: '{"key": [{"name": "a"}, {"name": "b"}, "x", "y"] }',
+      options: [
+        {
+          pathPattern: "^key$",
+          order: [
+            { key: "name", order: { type: "asc" } },
+            { order: { type: "asc" } },
+          ],
+        },
+      ],
+    },
+    // Array-of-matchers form using `key`.
+    {
+      code: '{"key": [{"name": "a"}, {"name": "b"}] }',
+      options: [
+        {
+          pathPattern: "^key$",
+          order: [{ key: "name", order: { type: "asc" } }],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -383,6 +434,81 @@ tester.run("sort-array-values", rule, {
         "Expected array values to be in ascending order. 'b' should be after 'a'.",
       ],
       ignoreMomoa: true,
+    },
+    // Object array out of order by `name` is reordered by autofix.
+    {
+      code: '{"categories": [{"name": "c"}, {"name": "b"}, {"name": "a"}] }',
+      output: `{"categories": [ {"name": "b"}, {"name": "a"},{"name": "c"}] }`,
+      options: [
+        { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
+      ],
+      errors: [
+        {
+          message:
+            "Expected array values to be in ascending by 'name' order. 'c' should be after 'a'.",
+          line: 1,
+          column: 17,
+        },
+        {
+          message:
+            "Expected array values to be in ascending by 'name' order. 'b' should be after 'a'.",
+          line: 1,
+          column: 32,
+        },
+      ],
+    },
+    // Missing key defaults to `"last"`: the key-less element moves to the end.
+    {
+      code: '{"categories": [{"name": "a"}, {"id": 1}, {"name": "b"}] }',
+      output: `{"categories": [{"name": "a"}, {"name": "b"}, {"id": 1}] }`,
+      options: [
+        { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
+      ],
+      errors: [
+        {
+          message:
+            "Expected array values to be in ascending by 'name' order. '{\"id\": 1}' should be after 'b'.",
+          line: 1,
+          column: 32,
+        },
+      ],
+    },
+    // `missingKey: "error"` reports the missing key but does not fix.
+    {
+      code: '{"categories": [{"name": "a"}, {"id": 1}, {"name": "b"}] }',
+      output: null,
+      options: [
+        {
+          pathPattern: "^categories$",
+          order: { type: "asc", key: "name", missingKey: "error" },
+        },
+      ],
+      errors: [
+        {
+          message: "Expected array value to have key 'name' to be sorted.",
+          line: 1,
+          column: 32,
+        },
+      ],
+    },
+    // Array-of-matchers composition using `key`.
+    {
+      code: '{"key": [{"name": "b"}, {"name": "a"}] }',
+      output: `{"key": [ {"name": "a"},{"name": "b"}] }`,
+      options: [
+        {
+          pathPattern: "^key$",
+          order: [{ key: "name", order: { type: "asc" } }],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Expected array values to be in specified order. \'{"name": "b"}\' should be after \'{"name": "a"}\'.',
+          line: 1,
+          column: 10,
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/sort-array-values.ts
+++ b/tests/lib/rules/sort-array-values.ts
@@ -60,24 +60,12 @@ tester.run("sort-array-values", rule, {
         { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
       ],
     },
-    // `missingKey: "last"` keeps key-less elements at the end.
+    // Elements missing the sort key are skipped — left in place and not
+    // compared against the sorted elements.
     {
-      code: '{"categories": [{"name": "a"}, {"name": "b"}, {"id": 1}] }',
+      code: '{"categories": [{"name": "a"}, {"id": 1}, {"name": "b"}] }',
       options: [
-        {
-          pathPattern: "^categories$",
-          order: { type: "asc", key: "name", missingKey: "last" },
-        },
-      ],
-    },
-    // `missingKey: "first"` keeps key-less elements at the start.
-    {
-      code: '{"categories": [{"id": 1}, {"name": "a"}, {"name": "b"}] }',
-      options: [
-        {
-          pathPattern: "^categories$",
-          order: { type: "asc", key: "name", missingKey: "first" },
-        },
+        { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
       ],
     },
     // Mixed array: objects sorted by `name`, primitives sorted by value,
@@ -452,40 +440,6 @@ tester.run("sort-array-values", rule, {
         {
           message:
             "Expected array values to be in ascending by 'name' order. 'b' should be after 'a'.",
-          line: 1,
-          column: 32,
-        },
-      ],
-    },
-    // Missing key defaults to `"last"`: the key-less element moves to the end.
-    {
-      code: '{"categories": [{"name": "a"}, {"id": 1}, {"name": "b"}] }',
-      output: `{"categories": [{"name": "a"}, {"name": "b"}, {"id": 1}] }`,
-      options: [
-        { pathPattern: "^categories$", order: { type: "asc", key: "name" } },
-      ],
-      errors: [
-        {
-          message:
-            "Expected array values to be in ascending by 'name' order. '{\"id\": 1}' should be after 'b'.",
-          line: 1,
-          column: 32,
-        },
-      ],
-    },
-    // `missingKey: "error"` reports the missing key but does not fix.
-    {
-      code: '{"categories": [{"name": "a"}, {"id": 1}, {"name": "b"}] }',
-      output: null,
-      options: [
-        {
-          pathPattern: "^categories$",
-          order: { type: "asc", key: "name", missingKey: "error" },
-        },
-      ],
-      errors: [
-        {
-          message: "Expected array value to have key 'name' to be sorted.",
           line: 1,
           column: 32,
         },

--- a/tests/lib/rules/sort-array-values.ts
+++ b/tests/lib/rules/sort-array-values.ts
@@ -76,19 +76,19 @@ tester.run("sort-array-values", rule, {
         {
           pathPattern: "^key$",
           order: [
-            { key: "name", order: { type: "asc" } },
+            { order: { type: "asc", key: "name" } },
             { order: { type: "asc" } },
           ],
         },
       ],
     },
-    // Array-of-matchers form using `key`.
+    // Array-of-matchers form using `order.key`.
     {
       code: '{"key": [{"name": "a"}, {"name": "b"}] }',
       options: [
         {
           pathPattern: "^key$",
-          order: [{ key: "name", order: { type: "asc" } }],
+          order: [{ order: { type: "asc", key: "name" } }],
         },
       ],
     },
@@ -445,14 +445,14 @@ tester.run("sort-array-values", rule, {
         },
       ],
     },
-    // Array-of-matchers composition using `key`.
+    // Array-of-matchers composition using `order.key`.
     {
       code: '{"key": [{"name": "b"}, {"name": "a"}] }',
       output: `{"key": [ {"name": "a"},{"name": "b"}] }`,
       options: [
         {
           pathPattern: "^key$",
-          order: [{ key: "name", order: { type: "asc" } }],
+          order: [{ order: { type: "asc", key: "name" } }],
         },
       ],
       errors: [


### PR DESCRIPTION
Close #514

## Summary

Adds a `key` option to `jsonc/sort-array-values` so arrays of objects can be sorted by a property value.

## Changes

- `order.key` — sort an array of objects by the value of this property (e.g. `{ "type": "asc", "key": "name" }`)
- Elements missing the `key` property are skipped — left in place and excluded from the sort
- `key` is also accepted in the array-of-matchers form, so object sorting can be composed with other value rules
- Mixed object/primitive arrays keep the two cohorts from interleaving (reuses the existing type-mismatch behavior)

## Tests

Added valid cases for sorted-by-key, key-less elements being skipped, mixed object+primitive arrays, and array-of-matchers with `key`. Added invalid cases for out-of-order autofix and array-of-matchers composition.

## Docs

Documented `key` in the options list and added examples for sorting object arrays by property key and array-form composition.
