### PR TITLE
feat(sort-keys): add ignore order option

### DIFF
--- a/.changeset/tidy-keys-rest.md
+++ b/.changeset/tidy-keys-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-jsonc": minor
+---
+
+Add an `ignore` order type to `jsonc/sort-keys` path options.

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -103,10 +103,30 @@ The option receives multiple objects with the following properties:
     - `type`:
       - `"asc"` ... Enforce properties to be in ascending order. This is default.
       - `"desc"` ... Enforce properties to be in descending order.
+      - `"ignore"` ... Do not enforce an order for properties at matching paths.
     - `caseSensitive` ... If `true`, enforce properties to be in case-sensitive order. Default is `true`.
     - `natural` ... If `true`, enforce properties to be in natural order. Default is `false`.
 - `minKeys` ... Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
 - `allowLineSeparatedGroups` ... If `true`, the rule allows to group object keys through line breaks. In other words, a blank line after a property will reset the sorting of keys. Default is `false`.
+
+Use `{ "type": "ignore" }` before a fallback option to preserve the existing
+property order at specific paths. For example, package export condition order
+can affect module resolution:
+
+```json5
+{
+    "jsonc/sort-keys": ["error",
+        {
+            "pathPattern": "^exports\\[\"\\.\"\\]$",
+            "order": { "type": "ignore" }
+        },
+        {
+            "pathPattern": ".*",
+            "order": { "type": "asc" }
+        }
+    ]
+}
+```
 
 You can also define options in the same format as the [sort-keys] rule.
 

--- a/lib/rules/sort-keys.ts
+++ b/lib/rules/sort-keys.ts
@@ -1,5 +1,6 @@
 import naturalCompare from "natural-compare";
 import { createRule } from "../utils/index.ts";
+import type { JSONSchema4 } from "json-schema";
 import type { AST } from "jsonc-eslint-parser";
 import { getStaticJSONValue } from "jsonc-eslint-parser";
 import {
@@ -32,6 +33,7 @@ type PatternOption = {
   hasProperties: string[];
   order:
     | OrderObject
+    | IgnoreOrderObject
     | (
         | string
         | {
@@ -46,6 +48,9 @@ type OrderObject = {
   type?: OrderTypeOption;
   caseSensitive?: boolean;
   natural?: boolean;
+};
+type IgnoreOrderObject = {
+  type: "ignore";
 };
 type ParsedOption = {
   isTargetObject: (node: JSONObjectData) => boolean;
@@ -216,6 +221,15 @@ function parseOptions(options: UserOptions): ParsedOption[] {
     const minKeys: number = opt.minKeys ?? 2;
     const allowLineSeparatedGroups = opt.allowLineSeparatedGroups || false;
     if (!Array.isArray(order)) {
+      if (order.type === "ignore") {
+        return {
+          isTargetObject,
+          ignore: () => true,
+          isValidOrder: () => true,
+          orderText: "ignored",
+          allowLineSeparatedGroups,
+        };
+      }
       const type: OrderTypeOption = order.type ?? "asc";
       const insensitive = order.caseSensitive === false;
       const natural = Boolean(order.natural);
@@ -310,6 +324,16 @@ const ORDER_OBJECT_SCHEMA = {
   },
   additionalProperties: false,
 } as const;
+const IGNORE_ORDER_OBJECT_SCHEMA: JSONSchema4 = {
+  type: "object",
+  properties: {
+    type: {
+      enum: ["ignore"],
+    },
+  },
+  required: ["type"],
+  additionalProperties: false,
+};
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -358,6 +382,7 @@ export default createRule<UserOptions>("sort-keys", {
                     uniqueItems: true,
                   },
                   ORDER_OBJECT_SCHEMA,
+                  IGNORE_ORDER_OBJECT_SCHEMA,
                 ],
               },
               minKeys: {

--- a/tests/lib/rules/sort-keys.ts
+++ b/tests/lib/rules/sort-keys.ts
@@ -84,6 +84,30 @@ tester.run("sort-keys", rule, {
       options: OPTIONS_FOR_JSON_SCHEMA,
     },
 
+    // ignore
+    {
+      code: `{
+        "exports": {
+          ".": {
+            "require": "./index.cjs",
+            "import": "./index.js",
+            "types": "./index.d.ts"
+          }
+        },
+        "name": "example"
+      }`,
+      options: [
+        {
+          pathPattern: '^exports\\["\\."\\]$',
+          order: { type: "ignore" },
+        },
+        {
+          pathPattern: ".*",
+          order: { type: "asc" },
+        },
+      ],
+    },
+
     // nest
     {
       code: `
@@ -284,6 +308,45 @@ tester.run("sort-keys", rule, {
     },
   ],
   invalid: [
+    {
+      code: `{
+        "dependencies": {
+          "z": "1.0.0",
+          "a": "1.0.0"
+        },
+        "exports": {
+          ".": {
+            "require": "./index.cjs",
+            "types": "./index.d.ts"
+          }
+        }
+      }`,
+      output: `{
+        "dependencies": {
+          "a": "1.0.0",
+          "z": "1.0.0"
+        },
+        "exports": {
+          ".": {
+            "require": "./index.cjs",
+            "types": "./index.d.ts"
+          }
+        }
+      }`,
+      options: [
+        {
+          pathPattern: '^exports\\["\\."\\]$',
+          order: { type: "ignore" },
+        },
+        {
+          pathPattern: ".*",
+          order: { type: "asc" },
+        },
+      ],
+      errors: [
+        "Expected object keys to be in ascending order. 'z' should be after 'a'.",
+      ],
+    },
     {
       code: '{"a": 1, "c": 3, "b": 2}',
       output: '{"a": 1, "b": 2, "c": 3}',


### PR DESCRIPTION
Closes #211.

## Summary
- add an explicit order: { type: "ignore" } path option
- preserve property order for matching objects while fallback options continue sorting elsewhere
- document the option and add a release changeset

## Validation
- npm test (1,565 passing)
- npm run tsc
- npm run build
- npm run docs:build
- changed-file ESLint

Full-repository lint also reports three unrelated baseline/environmental errors: two remote JSON schema resolution failures and the existing tools/update-rulesets.ts unbound-method finding.